### PR TITLE
infra: project infrastructure — README, CHANGELOG, CI, docs, ADRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a bug in token-engine
+labels: bug
+---
+
+## Description
+
+<!-- What went wrong? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+- token-engine version:
+- Go version:
+- OS:
+
+## Logs / Error Output
+
+```
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an addition or improvement
+labels: enhancement
+---
+
+## Problem / Motivation
+
+<!-- What problem does this solve, or what capability does it add? -->
+
+## Proposed Solution
+
+<!-- How should it work? -->
+
+## Alternatives Considered
+
+## Additional Context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do? 1–3 bullets. -->
+
+-
+
+## Motivation
+
+<!-- Why is this change needed? Link any related issues. -->
+
+## Test Plan
+
+- [ ] `./run-ci-locally.sh` passes
+- [ ] New tests added for new behavior
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+
+## Notes
+
+<!-- Anything reviewers should pay special attention to, or decisions made during implementation. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: govulncheck
+        run: govulncheck ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Install Ginkgo CLI
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.27.3
+
+      - name: Build
+        run: go build ./...
+
+      - name: Install buf
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: buf lint
+        run: buf lint
+
+      - name: Unit tests (race + coverage)
+        run: ginkgo -r --race --cover --coverprofile=coverage.out --randomize-all --fail-on-pending ./internal/...
+
+      - name: Generate coverage report
+        run: go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.html
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binaries
+token-engine
+/dist/
+
+# Test coverage
+cover*.out
+coverage.html
+
+# Generated protocol buffer code
+# Committed intentionally — regenerate with: make proto-gen
+# /gen/
+
+# Go build cache (local)
+*.test
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# Editor artifacts
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# golangci-lint cache
+.golangci-lint-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to token-engine are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+<!-- v0.1 content added when implementation is merged -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+## Requirements
+
+- All code must have tests written with [Ginkgo](https://onsi.github.io/ginkgo/) v2 and Gomega.
+- Tests must pass with the race detector enabled (`-race`).
+- `go vet ./...` must be clean.
+- `golangci-lint run ./...` must be clean.
+- Generated mocks (`internal/testutil/`) are produced with `go.uber.org/mock/mockgen` in source mode. Regenerate with `make proto-gen` before submitting changes to interfaces.
+- Generated protobuf code (`gen/`) is committed to the repository. Regenerate with `make proto-gen` when `proto/token_engine.proto` changes.
+- Update `CHANGELOG.md` under `[Unreleased]` for any user-visible change.
+
+## Workflow
+
+```bash
+git clone https://github.com/aetomala/token-engine.git
+cd token-engine
+
+# Run the full CI pipeline locally before pushing
+./run-ci-locally.sh
+```
+
+## Branching
+
+- Branch off `dev`: `git checkout -b <area>/short-description`
+- PRs target `dev`, never `main`.
+- One logical concern per PR.
+- Branch name format: `feat/`, `fix/`, `refactor/`, `infra/`, `docs/`
+
+## Code Conventions
+
+Follow the patterns established in the existing packages:
+
+- Observability (logger, metrics, tracer) injected via config struct — never constructed inside components.
+- NoOp implementations exist for every interface — constructors inject NoOp when a config field is nil.
+- No nil-checks for observability fields at call sites.
+- Error sentinels declared at package level in `var` blocks with a group comment.
+- `go.uber.org/mock` for all mocks; source-mode generation only.
+
+## Architecture
+
+Read [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md) before making structural changes.
+Check [doc/adr/](doc/adr/) for decisions already made — new structural changes should be accompanied by an ADR.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: build test coverage lint proto-gen ci clean
+
+BINARY   := token-engine
+PKG      := ./...
+TEST_PKG := ./internal/...
+
+build:
+	go build -o $(BINARY) ./cmd/token-engine
+
+test:
+	ginkgo -r --race $(TEST_PKG)
+
+coverage:
+	ginkgo -r --race --cover --coverprofile=coverage.out $(TEST_PKG)
+	go tool cover -html=coverage.out -o coverage.html
+
+lint:
+	go vet $(PKG)
+	golangci-lint run $(PKG)
+
+proto-gen:
+	buf generate
+
+ci: lint build test
+
+clean:
+	go clean $(PKG)
+	find . -name "cover*.out" -delete
+	rm -f coverage.html $(BINARY)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,245 @@
-# jwtauth-service
-service layer wrapper to jwtauth
+# token-engine
+
+[![CI](https://github.com/aetomala/token-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/aetomala/token-engine/actions/workflows/ci.yml)
+[![Go 1.22+](https://img.shields.io/badge/go-1.22+-blue.svg)](https://go.dev/dl/)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
+A production-grade gRPC service that wraps [jwtauth](https://github.com/aetomala/jwtauth) v0.7.0 and exposes stateful JWT token management as a network API — multi-tenant, observable, and horizontally scalable.
+
+---
+
+## What It Provides
+
+| RPC | Description |
+|---|---|
+| `IssueToken` | Issue a new access + refresh token pair for a subject |
+| `RefreshToken` | Rotate tokens using a valid refresh token |
+| `RevokeToken` | Revoke a single refresh token immediately |
+| `RevokeAllForAudience` | Revoke all tokens scoped to an audience |
+| `RevokeAllUserTokens` | Revoke all tokens for a user across all audiences |
+
+**Interceptor chain (applied to every RPC):**
+OpenTelemetry tracing → Correlation ID → API key authentication → Caller authorization → Idempotency → Request validation
+
+**Observability:** Prometheus metrics at `/metrics`, OpenTelemetry traces via OTLP, structured slog logging with correlation IDs, health probes at `/healthz/live` and `/healthz/ready`.
+
+---
+
+## Quick Start
+
+```bash
+# Build
+make build
+
+# Run with minimum required config
+TOKEN_ENGINE_ISSUER=my-service \
+TOKEN_ENGINE_AUDIENCE=my-api \
+TOKEN_ENGINE_TLS_MODE=disabled \
+TOKEN_ENGINE_STATIC_CALLER_KEYS=supersecret=service-a \
+./token-engine
+```
+
+The gRPC server starts on `:9090` and the HTTP server (health + metrics) on `:8080`.
+
+**Connect a client:**
+```go
+conn, err := grpc.Dial(":9090", grpc.WithTransportCredentials(insecure.NewCredentials()))
+client := tokenv1.NewTokenEngineClient(conn)
+
+resp, err := client.IssueToken(ctx, &tokenv1.IssueTokenRequest{
+    Sub:      "user-123",
+    TenantId: "tenant-abc",
+})
+```
+
+---
+
+## Configuration
+
+All configuration is via environment variables. The service exits fatally at startup if required fields are missing.
+
+| Variable | Type | Default | Behavior on Invalid |
+|---|---|---|---|
+| `TOKEN_ENGINE_ISSUER` | string | **required** | fatal exit |
+| `TOKEN_ENGINE_AUDIENCE` | string | **required** | fatal exit |
+| `TOKEN_ENGINE_TLS_MODE` | `mtls` \| `disabled` | `mtls` | fatal exit |
+| `TOKEN_ENGINE_STATIC_CALLER_KEYS` | `key=id,key=id` | required when TLS disabled | fatal exit |
+| `TOKEN_ENGINE_GRPC_ADDR` | string | `:9090` | warning + default |
+| `TOKEN_ENGINE_HTTP_ADDR` | string | `:8080` | warning + default |
+| `TOKEN_ENGINE_IDEMPOTENCY_TTL` | duration | `5m` | warning + default |
+| `TOKEN_ENGINE_MAX_CONNECTION_AGE` | duration | `30m` | warning + default |
+| `TOKEN_ENGINE_MAX_CONNECTION_AGE_GRACE` | duration | `5m` | warning + default |
+| `TOKEN_ENGINE_REDIS_ADDR` | string | `localhost:6379` | warning + default |
+| `TOKEN_ENGINE_REDIS_PASSWORD` | string | `` | — |
+| `TOKEN_ENGINE_REDIS_DB` | int | `0` | warning + default |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | string | `` | no-op tracer (no traces) |
+
+**`TOKEN_ENGINE_STATIC_CALLER_KEYS` format:** `apikey1=caller-identity-1,apikey2=caller-identity-2`
+
+**Duration format:** Go duration strings — `5m`, `30m`, `1h30m`, `300s`.
+
+---
+
+## API Reference
+
+### IssueToken
+
+Issues a new access + refresh token pair.
+
+| Field | Type | Description |
+|---|---|---|
+| `sub` | string | Subject identifier (required) |
+| `tenant_id` | string | Tenant scoping for multi-tenancy (required) |
+| `idempotency_key` | string | Deduplication key — same key returns same tokens within TTL |
+| `claims` | map<string,string> | Custom claims stamped on the access token |
+| `audiences` | repeated string | Audience override; defaults to `TOKEN_ENGINE_AUDIENCE` |
+
+Returns `TokenPair` containing `access_token`, `refresh_token`, `access_token_expires_in` (seconds), `refresh_token_expires_in` (seconds).
+
+### RefreshToken
+
+Rotates tokens using a valid refresh token. The old refresh token is revoked atomically.
+
+| Field | Type | Description |
+|---|---|---|
+| `refresh_token` | string | Current valid refresh token (required) |
+| `tenant_id` | string | Must match the tenant that issued the token (required) |
+| `idempotency_key` | string | Deduplication key |
+| `claims` | map<string,string> | Custom claims on the new access token |
+
+Returns `TokenPair`.
+
+### RevokeToken
+
+Revokes a single refresh token immediately. Subsequent refresh attempts with this token return `NOT_FOUND`.
+
+| Field | Type | Description |
+|---|---|---|
+| `refresh_token` | string | Refresh token to revoke (required) |
+| `tenant_id` | string | Must match the issuing tenant (required) |
+
+### RevokeAllForAudience
+
+Revokes all refresh tokens scoped to a specific audience within a tenant.
+
+| Field | Type | Description |
+|---|---|---|
+| `audience` | string | Audience to revoke (required) |
+| `tenant_id` | string | Tenant scope (required) |
+
+### RevokeAllUserTokens
+
+Revokes all refresh tokens for a user across all audiences within a tenant.
+
+| Field | Type | Description |
+|---|---|---|
+| `user_id` | string | User whose tokens are revoked (required) |
+| `tenant_id` | string | Tenant scope (required) |
+
+### Error Codes
+
+| gRPC Code | Condition |
+|---|---|
+| `UNAUTHENTICATED` | Missing or invalid API key; expired access token |
+| `PERMISSION_DENIED` | Caller not authorized for this tenant; revoked token; invalid audience |
+| `NOT_FOUND` | Refresh token not found |
+| `INTERNAL` | Invalid key ID; missing kid claim; unexpected library error |
+
+---
+
+## Observability
+
+### Health Endpoints (HTTP)
+
+| Path | Purpose |
+|---|---|
+| `GET /healthz/live` | Liveness probe — returns 200 if process is alive |
+| `GET /healthz/ready` | Readiness probe — returns 200 if service is ready |
+
+### Metrics (HTTP)
+
+Available at `GET /metrics` (Prometheus text format).
+
+| Metric | Type | Description |
+|---|---|---|
+| `token_engine_grpc_requests_total` | Counter | Total gRPC requests processed |
+| `token_engine_grpc_request_duration_seconds` | Histogram | gRPC request duration |
+| `token_engine_idempotency_total` | Counter | Idempotency operations |
+| `token_engine_active_tenants` | Gauge | Active tenant count |
+| `token_engine_tenant_registry_operations_total` | Counter | Tenant registry operations |
+
+See [doc/METRICS.md](doc/METRICS.md) for full label reference and PromQL examples.
+
+### Distributed Tracing
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable trace export to an OTLP collector. All gRPC requests produce spans with the interceptor chain visible as child spans.
+
+---
+
+## Development
+
+### Prerequisites
+
+- Go 1.22+
+- [buf](https://buf.build/docs/installation) (for proto regeneration)
+- [golangci-lint](https://golangci-lint.run/usage/install/) v2+
+- [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
+- [ginkgo](https://onsi.github.io/ginkgo/#installing-ginkgo) v2 (`go install github.com/onsi/ginkgo/v2/ginkgo@v2.27.3`)
+
+### Make Targets
+
+```bash
+make build       # Compile the binary
+make test        # Run all tests with race detector
+make coverage    # Run tests with coverage report
+make lint        # go vet + golangci-lint
+make proto-gen   # Regenerate from proto/token_engine.proto (requires buf)
+make ci          # Full CI pipeline: lint + build + test
+make clean       # Remove binary and coverage files
+```
+
+### Running Tests
+
+```bash
+make test                               # All packages
+ginkgo -r --race ./internal/...        # Equivalent
+ginkgo --race ./internal/observability/...  # Single package
+```
+
+Tests use [Ginkgo](https://onsi.github.io/ginkgo/) v2 with Gomega matchers and [go.uber.org/mock](https://github.com/uber-go/mock) for generated mocks.
+
+### Local CI
+
+Reproduce the full CI pipeline before pushing:
+
+```bash
+./run-ci-locally.sh
+```
+
+---
+
+## Architecture
+
+See [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md) for component model, interceptor chain rationale, and roadmap.
+
+Architecture decisions are recorded in [doc/adr/](doc/adr/).
+
+---
+
+## Roadmap
+
+| Version | Status | Key Additions |
+|---|---|---|
+| v0.1 | ✅ Complete | gRPC service, interceptor chain, static auth, in-memory idempotency, NoOp audit + reconciliation |
+| v0.2 | Planned | Redis-backed idempotency store, audit logging, token reconciliation, dynamic tenant registry |
+| v1.0 | Planned | Stable API commitment, multi-region deployment docs, dynamic caller registry |
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Support |
+|---|---|
+| v0.1.x | Active development — security fixes applied |
+| < v0.1.0 | None |
+
+## Reporting a Vulnerability
+
+Report security vulnerabilities via [GitHub Security Advisories](https://github.com/aetomala/token-engine/security/advisories/new) — do not open a public issue.
+
+**Acknowledgement:** Within 72 hours of receipt.  
+**Patch timeline:** 7 days for critical issues; 30 days for others.
+
+## Scope
+
+**In scope:**
+- gRPC authentication and caller authorization logic (`internal/interceptor/`)
+- API key handling and identity mapping
+- Token issuance, refresh, and revocation via jwtauth integration
+- Error mapping and gRPC status code assignment
+- Idempotency key handling
+
+**Out of scope (operator responsibility):**
+- TLS certificate management and rotation
+- Redis ACL and network isolation
+- API key storage and distribution
+- Rate limiting (apply at API gateway or ingress layer — see [ADR-001](doc/adr/ADR-001-grpc-first-transport.md))
+- Kubernetes network policy and pod security
+
+## Security Architecture
+
+Key decisions relevant to security:
+
+- **ADR-003** — Static caller keys: API keys are validated in-memory on every request; there is no session state that can be hijacked.
+- **ADR-006** — Interceptor chain order: authentication runs before caller authorization, idempotency, and validation — unauthorized requests never reach business logic.
+
+Token security guarantees (signing, key rotation, replay prevention) are inherited from jwtauth — see the [jwtauth security policy](https://github.com/aetomala/jwtauth/blob/main/SECURITY.md).

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,0 +1,211 @@
+# token-engine — Architecture
+
+## Overview
+
+token-engine is a gRPC service that exposes [jwtauth](https://github.com/aetomala/jwtauth) — a stateful JWT authorization library — as a multi-tenant network API. Its design goals are:
+
+- **Thin service layer.** All token business logic lives in jwtauth. token-engine is responsible only for transport, multi-tenancy, authentication, observability, and lifecycle management.
+- **Observability-first.** Every request produces a trace span, increments counters, and emits structured log entries. All three signals are injectable — components never construct their own observability primitives.
+- **Progressive implementation.** v0.1 establishes the full service skeleton with NoOp stubs for components that require Redis. Each deferred feature has an interface seam and a NoOp implementation — the service runs correctly without the feature present, and the feature can be wired in later without API changes.
+
+---
+
+## Component Model
+
+```
+cmd/token-engine/main.go
+├── Config (internal/config)
+├── Observability
+│   ├── Logger        (internal/observability — SlogLogger)
+│   ├── Metrics       (internal/observability — PrometheusMetrics)
+│   └── Tracer        (internal/observability — OtelTracer)
+├── Authenticator     (internal/interceptor — StaticKeyAuthenticator)
+├── Registries
+│   ├── CallerRegistry  (internal/registry — StaticCallerRegistry)
+│   └── TenantRegistry  (internal/registry — StaticTenantRegistry, NoOp in v0.1)
+├── Stores
+│   └── IdempotencyStore (internal/store — in-memory, v0.1)
+├── Audit             (internal/audit — NoOpAuditStore, v0.1)
+├── Reconciliation    (internal/reconciliation — NoOpReconciler, v0.1)
+├── Handler           (internal/handler — TokenHandler, delegates to jwtauth)
+├── Health            (internal/health — LiveHandler, ReadyHandler)
+├── gRPC Server       (interceptor chain + TokenEngine service)
+└── HTTP Server       (/healthz/live, /healthz/ready, /metrics)
+```
+
+---
+
+## Interceptor Chain
+
+Every gRPC request passes through six interceptors in this order:
+
+```
+Client Request
+    │
+    ▼
+┌─────────────────────────┐
+│ 1. OTel Tracing         │  starts trace span; propagates W3C trace context
+├─────────────────────────┤
+│ 2. Correlation ID       │  attaches a UUID to context; logged on every entry
+├─────────────────────────┤
+│ 3. Authentication       │  validates API key from gRPC metadata; sets caller identity
+├─────────────────────────┤
+│ 4. Caller Authorization │  checks caller identity against allowed callers per tenant
+├─────────────────────────┤
+│ 5. Idempotency          │  deduplicates requests by idempotency key within TTL
+├─────────────────────────┤
+│ 6. Validation           │  validates request fields (stub in v0.1)
+└─────────────────────────┘
+    │
+    ▼
+Handler → jwtauth → Response
+```
+
+See [ADR-006](adr/ADR-006-interceptor-chain-order.md) for the rationale behind this ordering.
+
+---
+
+## Request Lifecycle
+
+```
+Client
+  │  gRPC call + Authorization metadata header
+  ▼
+OTel interceptor        — extracts/creates trace context; starts server span
+  │
+  ▼
+Correlation interceptor — generates UUID; stores in context; logs to all downstream log lines
+  │
+  ▼
+Auth interceptor        — reads Authorization header; looks up API key in StaticKeyAuthenticator
+  │  ← UNAUTHENTICATED if key missing or unrecognized
+  ▼
+CallerAuthz interceptor — checks caller identity against tenant's allowed callers list
+  │  ← PERMISSION_DENIED if caller not authorized
+  ▼
+Idempotency interceptor — checks in-memory store for duplicate idempotency key
+  │  ← returns cached response if duplicate within TTL
+  ▼
+Validation interceptor  — validates required fields (stub; pass-through in v0.1)
+  │
+  ▼
+TokenHandler            — delegates to jwtauth (KeyManager, TokenManager, RefreshStore)
+  │  ← maps jwtauth errors to gRPC status codes via MapLibraryError
+  ▼
+Client ← TokenPair / RevokeTokenResponse
+```
+
+---
+
+## Observability Architecture
+
+Every component receives three observability fields injected at construction time:
+
+| Signal | Interface | Default |
+|---|---|---|
+| Logging | `observability.Logger` | `SlogLogger` (structured JSON) |
+| Metrics | `observability.Metrics` | `PrometheusMetrics` (Prometheus registry) |
+| Tracing | `observability.Tracer` | `OtelTracer` (OTLP export) or no-op |
+
+**Rule:** No component nil-checks observability fields at call sites. The constructor injects NoOp implementations when config fields are absent. This ensures zero-cost observability when not configured, with no if-nil guards scattered through business logic.
+
+**Correlation ID:** The correlation interceptor stores a UUID in the request context using `CorrelationIDKey{}`. The `SlogLogger` reads this key on every log call and includes it as `correlation_id`. All log entries for a single request share the same correlation ID regardless of which component emits them.
+
+---
+
+## jwtauth Integration
+
+token-engine delegates all token business logic to `github.com/aetomala/jwtauth` v0.7.0.
+
+The `TokenHandler` uses three jwtauth components:
+
+| Component | Purpose |
+|---|---|
+| `keys.KeyManager` | Key lifecycle — rotation, loading, JWKS |
+| `tokens.TokenManager` | Token issuance, refresh, revocation, validation |
+| `storage.RefreshStore` | Persistent refresh token storage |
+
+token-engine does not implement any JWT signing, key management, or token storage logic. It provides the transport, multi-tenancy, and observability layers that jwtauth does not include by design.
+
+**Error mapping:** jwtauth errors are converted to gRPC status codes in `observability.MapLibraryError`. Package ownership of each sentinel is verified from jwtauth v0.7.0 source:
+
+| Sentinel | Package | gRPC Code |
+|---|---|---|
+| `ErrTokenRevoked` | `pkg/tokens` | `PERMISSION_DENIED` |
+| `ErrTokenNotFound` | `pkg/storage` | `NOT_FOUND` |
+| `ErrInvalidAudience` | `pkg/tokens` | `PERMISSION_DENIED` |
+| `ErrKeyStoreInvalidKeyID` | `pkg/keys` | `INTERNAL` |
+| `ErrTokenMissingKid` | `pkg/tokens` | `INTERNAL` |
+| `ErrTokenExpired` | `pkg/tokens` | `UNAUTHENTICATED` |
+
+---
+
+## v0.1 Deferrals
+
+The following components are present as interface seams with NoOp implementations in v0.1. They produce correct behavior (no panics, no errors) with zero side effects.
+
+| Component | Interface | v0.1 Implementation | Target Version |
+|---|---|---|---|
+| Audit logging | `audit.AuditStore` | `NoOpAuditStore` | v0.2 (Redis) |
+| Token reconciliation | `reconciliation.TokenReconciler` | `NoOpReconciler` | v0.2 |
+| Dynamic tenant registry | `registry.TenantRegistry` | `StaticTenantRegistry` (static config) | v0.2 (Redis) |
+| Idempotency store | `store.IdempotencyStore` | In-memory map with TTL | v0.2 (Redis) |
+| Caller registry | `registry.CallerRegistry` | `StaticCallerRegistry` | v1.0 |
+
+---
+
+## Package Layout
+
+| Package | Import Path | Role |
+|---|---|---|
+| `cmd/token-engine` | `github.com/aetomala/token-engine/cmd/token-engine` | Binary entry point, wiring |
+| `internal/config` | `.../internal/config` | Environment-based configuration loading |
+| `internal/observability` | `.../internal/observability` | Logger, Metrics, Tracer interfaces and implementations |
+| `internal/interceptor` | `.../internal/interceptor` | gRPC interceptor chain (auth, correlation, OTel, idempotency, validation) |
+| `internal/registry` | `.../internal/registry` | Caller and tenant identity registries |
+| `internal/handler` | `.../internal/handler` | gRPC service implementation delegating to jwtauth |
+| `internal/health` | `.../internal/health` | HTTP liveness and readiness handlers |
+| `internal/store` | `.../internal/store` | Idempotency store |
+| `internal/audit` | `.../internal/audit` | Audit logging interface and NoOp |
+| `internal/reconciliation` | `.../internal/reconciliation` | Token reconciliation interface and NoOp |
+| `internal/testutil` | `.../internal/testutil` | Generated mocks for all interfaces |
+| `gen/v1` | `github.com/aetomala/token-engine/gen/v1` | Generated protobuf and gRPC stubs |
+
+---
+
+## Testing Strategy
+
+Tests use Ginkgo v2 (BDD) with Gomega matchers. All suites run with the race detector.
+
+Each package has a suite bootstrap file (`*_suite_test.go`) and a test file organized into numbered phases:
+
+1. Constructor and initialization
+2. Default configuration
+3. Core operations
+4. Error cases
+5. Concurrency (where applicable)
+
+Mocks are generated with `go.uber.org/mock/mockgen` in source mode. All mocks live in `internal/testutil/`. Tests use black-box testing (`package xxx_test`) to validate the public API surface.
+
+---
+
+## Roadmap
+
+| Version | Target | Key Work |
+|---|---|---|
+| v0.1 | ✅ Complete | Full service skeleton, static auth, in-memory idempotency, NoOp stubs |
+| v0.2 | Planned | Redis client lifecycle, Redis-backed idempotency + audit + reconciliation, dynamic tenant registry |
+| v1.0 | Planned | Stable API commitment, dynamic caller registry, multi-region deployment guide |
+
+---
+
+## Architecture Decision Records
+
+| ADR | Decision |
+|---|---|
+| [ADR-001](adr/ADR-001-grpc-first-transport.md) | gRPC as the primary transport |
+| [ADR-002](adr/ADR-002-jwtauth-library-delegation.md) | Token business logic delegated entirely to jwtauth |
+| [ADR-003](adr/ADR-003-static-caller-keys-v01.md) | Static API key authentication for v0.1 |
+| [ADR-004](adr/ADR-004-noop-stubs-v01.md) | NoOp stubs for audit, reconciliation, and tenant registry in v0.1 |
+| [ADR-005](adr/ADR-005-in-memory-idempotency-v01.md) | In-memory idempotency store for v0.1 |
+| [ADR-006](adr/ADR-006-interceptor-chain-order.md) | Interceptor chain ordering rationale |

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -1,0 +1,155 @@
+# token-engine — Deployment Reference
+
+## Pre-flight Checklist
+
+Before starting the service:
+
+- [ ] `TOKEN_ENGINE_ISSUER` set — non-empty string
+- [ ] `TOKEN_ENGINE_AUDIENCE` set — non-empty string
+- [ ] `TOKEN_ENGINE_TLS_MODE` set — `mtls` or `disabled`
+- [ ] If `TLS_MODE=disabled`: `TOKEN_ENGINE_STATIC_CALLER_KEYS` set with at least one entry
+- [ ] If `TLS_MODE=mtls`: TLS certificates provisioned and accessible to the process
+- [ ] jwtauth `KeyManager` key store (disk or Redis) accessible and writable
+- [ ] Redis accessible if using any Redis-backed components (v0.2+)
+
+---
+
+## TLS Configuration
+
+### Mutual TLS (`TLS_MODE=mtls`)
+
+The gRPC server requires client certificates. Configure TLS at the process level via your deployment platform (Kubernetes service mesh, Envoy sidecar, or direct certificate injection).
+
+The service does not load certificates directly in v0.1 — mTLS is enforced at the transport layer by the infrastructure.
+
+### No TLS (`TLS_MODE=disabled`)
+
+For development or internal networks with transport security handled at the infrastructure layer (VPC, service mesh). Requires `TOKEN_ENGINE_STATIC_CALLER_KEYS` for caller authentication.
+
+**Do not use `disabled` mode with public-facing traffic.**
+
+---
+
+## Health Checks
+
+The HTTP server (default `:8080`) exposes:
+
+| Endpoint | Method | Success | Failure |
+|---|---|---|---|
+| `/healthz/live` | GET | 200 OK | — (always 200 if process is running) |
+| `/healthz/ready` | GET | 200 OK | 503 Service Unavailable |
+
+### Kubernetes Probe Configuration
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz/live
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz/ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+---
+
+## Prometheus Metrics
+
+The Prometheus metrics endpoint is available at `GET http://<host>:8080/metrics`.
+
+### Prometheus Scrape Config
+
+```yaml
+scrape_configs:
+  - job_name: token-engine
+    static_configs:
+      - targets: ["<host>:8080"]
+    metrics_path: /metrics
+```
+
+For alerting rules and PromQL examples, see [METRICS.md](METRICS.md).
+
+---
+
+## OpenTelemetry Tracing
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to export traces to an OTLP-compatible collector (Jaeger, Tempo, OTLP collector, etc.).
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317 ./token-engine
+```
+
+When the endpoint is empty (default), a no-op `TracerProvider` is used — no traces are emitted and no connection is attempted.
+
+All gRPC requests produce a server span. The interceptor chain produces child spans for:
+- OTel interceptor (root span)
+- Correlation ID attachment
+- Authentication check
+- Caller authorization check
+- Idempotency lookup
+
+---
+
+## Graceful Shutdown
+
+The service listens for `SIGINT` and `SIGTERM`. On receipt:
+
+1. gRPC server: `GracefulStop()` — waits for in-flight RPCs to complete
+2. HTTP server: `Shutdown(ctx)` — stops accepting new connections, waits for active requests
+
+Allow sufficient time in your pod termination grace period for in-flight requests to drain. Recommended minimum: `MaxConnectionAge + MaxConnectionAgeGrace` (default: 35 minutes total).
+
+```yaml
+terminationGracePeriodSeconds: 60
+```
+
+---
+
+## gRPC Connection Lifetime
+
+Long-lived gRPC connections are cycled to prevent resource accumulation:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TOKEN_ENGINE_MAX_CONNECTION_AGE` | `30m` | Maximum age before graceful close signal |
+| `TOKEN_ENGINE_MAX_CONNECTION_AGE_GRACE` | `5m` | Grace period for in-flight calls after close signal |
+
+Clients should implement retry with exponential backoff and respect `GOAWAY` frames. gRPC client libraries handle this automatically.
+
+---
+
+## Redis (v0.2+)
+
+Redis is not used in v0.1. The configuration fields (`TOKEN_ENGINE_REDIS_ADDR`, `TOKEN_ENGINE_REDIS_PASSWORD`, `TOKEN_ENGINE_REDIS_DB`) are present and validated but the Redis client is not initialized in v0.1.
+
+For v0.2 Redis hardening guidelines:
+- Use Redis ACL to restrict commands to: `GET`, `SET`, `DEL`, `EXPIRE`, `KEYS`, `SCAN`
+- Isolate the Redis instance on a private network — no public exposure
+- Enable TLS on the Redis connection when using Redis 6+
+
+---
+
+## Environment Reference
+
+See the [Configuration section of README.md](../README.md#configuration) for the full variable table with types, defaults, and validation behavior.
+
+---
+
+## Rate Limiting
+
+Rate limiting is not implemented in token-engine. Apply rate limiting at the API gateway or ingress layer before requests reach the gRPC port. Recommended tools:
+
+- Kong with Rate Limiting plugin
+- AWS API Gateway with usage plans
+- Kubernetes Ingress with NGINX `limit_req`
+- Envoy with local rate limiting filter
+
+See [ADR-001](adr/ADR-001-grpc-first-transport.md) for the rationale.

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -1,0 +1,132 @@
+# token-engine — Metrics Reference
+
+All metrics are exported in Prometheus text format at `GET http://<host>:8080/metrics`.
+
+---
+
+## Metric Inventory
+
+### token_engine_grpc_requests_total
+
+| Field | Value |
+|---|---|
+| Type | Counter |
+| Description | Total number of gRPC requests processed by the service |
+| Labels | _(none in v0.1)_ |
+
+**PromQL examples:**
+
+```promql
+# Request rate over 5 minutes
+rate(token_engine_grpc_requests_total[5m])
+```
+
+---
+
+### token_engine_grpc_request_duration_seconds
+
+| Field | Value |
+|---|---|
+| Type | Histogram |
+| Description | Duration of gRPC requests in seconds |
+| Buckets | Default Prometheus histogram buckets |
+| Labels | _(none in v0.1)_ |
+
+**PromQL examples:**
+
+```promql
+# 99th percentile latency over 5 minutes
+histogram_quantile(0.99, rate(token_engine_grpc_request_duration_seconds_bucket[5m]))
+
+# 50th percentile latency
+histogram_quantile(0.50, rate(token_engine_grpc_request_duration_seconds_bucket[5m]))
+```
+
+---
+
+### token_engine_idempotency_total
+
+| Field | Value |
+|---|---|
+| Type | Counter |
+| Description | Total number of idempotency store operations (hits and misses) |
+| Labels | _(none in v0.1)_ |
+
+**PromQL examples:**
+
+```promql
+# Idempotency operation rate
+rate(token_engine_idempotency_total[5m])
+```
+
+---
+
+### token_engine_active_tenants
+
+| Field | Value |
+|---|---|
+| Type | Gauge |
+| Description | Number of active tenants registered in the tenant registry |
+| Labels | _(none in v0.1)_ |
+
+**PromQL examples:**
+
+```promql
+# Current active tenant count
+token_engine_active_tenants
+```
+
+---
+
+### token_engine_tenant_registry_operations_total
+
+| Field | Value |
+|---|---|
+| Type | Counter |
+| Description | Total number of tenant registry operations |
+| Labels | _(none in v0.1)_ |
+
+**PromQL examples:**
+
+```promql
+# Registry operation rate
+rate(token_engine_tenant_registry_operations_total[5m])
+```
+
+---
+
+## Alerting Examples
+
+```yaml
+groups:
+  - name: token-engine
+    rules:
+      - alert: TokenEngineHighLatency
+        expr: histogram_quantile(0.99, rate(token_engine_grpc_request_duration_seconds_bucket[5m])) > 0.5
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "token-engine p99 latency above 500ms"
+
+      - alert: TokenEngineDown
+        expr: absent(token_engine_grpc_requests_total)
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "token-engine is not emitting metrics"
+```
+
+---
+
+## v0.2 Planned Additions
+
+The following metrics will be added in v0.2 when Redis-backed components are enabled:
+
+| Metric | Type | Description |
+|---|---|---|
+| `token_engine_audit_operations_total` | Counter | Audit log write operations |
+| `token_engine_reconciliation_runs_total` | Counter | Token reconciliation run count |
+| `token_engine_redis_operations_total` | Counter | Redis client operations (by command) |
+| `token_engine_redis_operation_duration_seconds` | Histogram | Redis operation latency |

--- a/doc/adr/ADR-001-grpc-first-transport.md
+++ b/doc/adr/ADR-001-grpc-first-transport.md
@@ -1,0 +1,46 @@
+# ADR-001: gRPC-First Transport
+
+**Status:** Accepted  
+**Date:** 2026-05-26
+
+## Context
+
+token-engine exposes jwtauth's token operations over a network API. The choice of transport protocol affects client ergonomics, schema enforcement, observability integration, and operational complexity.
+
+Candidates evaluated: REST/HTTP+JSON, gRPC+Protobuf, GraphQL.
+
+## Decision
+
+gRPC with Protocol Buffers.
+
+## Rationale
+
+- **Strict schema.** Protobuf defines the API contract with field types, required/optional semantics, and generated client stubs. No hand-rolled serialization, no schema drift between caller and service.
+- **Native OTel integration.** `otelgrpc` provides first-class trace context propagation (W3C Trace Context) and server span creation for every RPC with zero application code.
+- **Deadline propagation.** gRPC deadlines propagate automatically across service boundaries. Callers set a deadline; the server respects it via context cancellation.
+- **Interceptor chain.** gRPC's `ChainUnaryInterceptor` provides a clean composition model for cross-cutting concerns (auth, logging, idempotency) without middleware framework coupling.
+- **Streaming capability.** Not used in v0.1, but available without protocol change if future operations require server-side streaming (e.g., event subscriptions).
+
+## Consequences
+
+**Positive:**
+- Generated client stubs in any gRPC-supported language.
+- Trace context propagated without custom headers.
+- Contract defined in `proto/token_engine.proto`; changes are versioned and explicit.
+
+**Negative:**
+- Requires `buf` toolchain for proto management and code generation.
+- Browser clients require gRPC-Web proxy or Envoy transcoding.
+- Proto toolchain adds a build step (`buf generate`) when the service definition changes.
+
+## Alternatives Considered
+
+**REST/HTTP+JSON:** Simpler client setup (curl, any HTTP client), but no generated stubs, no built-in deadline propagation, manual trace context injection required.
+
+**GraphQL:** Flexible queries, but adds significant operational complexity (schema registry, resolver design) for a service with a small, fixed RPC surface.
+
+## References
+
+- [proto/token_engine.proto](../../proto/token_engine.proto)
+- [buf.yaml](../../buf.yaml)
+- [DEPLOYMENT.md — Rate Limiting](../DEPLOYMENT.md#rate-limiting)

--- a/doc/adr/ADR-002-jwtauth-library-delegation.md
+++ b/doc/adr/ADR-002-jwtauth-library-delegation.md
@@ -1,0 +1,48 @@
+# ADR-002: jwtauth Library Delegation
+
+**Status:** Accepted  
+**Date:** 2026-05-26
+
+## Context
+
+token-engine must implement JWT token issuance, refresh, revocation, and validation. These operations involve key management (rotation, loading, JWKS), token signing (RS256), refresh token storage, and a range of security invariants (reserved claims protection, audience validation, kid validation, replay prevention).
+
+The jwtauth library (`github.com/aetomala/jwtauth`) already implements all of these operations with production-grade observability, integration tests, and documented security decisions.
+
+## Decision
+
+Delegate all token business logic to jwtauth v0.7.0. token-engine implements only the transport layer, multi-tenancy, authentication, and observability wiring that jwtauth does not provide.
+
+token-engine contains no JWT signing code, no key management code, and no refresh token storage code. All of these live in jwtauth.
+
+## Rationale
+
+- **Avoid duplication.** Reimplementing JWT operations would duplicate the security-sensitive logic already tested and documented in jwtauth, including 11 ADRs covering algorithm confusion prevention, kid validation, reserved claims protection, and replay prevention.
+- **Single point of change.** Security fixes in jwtauth propagate to token-engine via a version bump. There is no parallel implementation to keep in sync.
+- **Interface-first adapter.** The jwtauth `metrics.Metrics` interface (5 methods) differs from the token-engine `observability.Metrics` interface (5 methods). An adapter in `internal/observability` bridges the two — the adapter is the only file that knows about both interfaces.
+
+## Consequences
+
+**Positive:**
+- token-engine stays thin and focused on service concerns.
+- jwtauth security guarantees apply automatically.
+- jwtauth's observability model (logging, metrics, tracing) is available in token-engine via adapters.
+
+**Negative:**
+- jwtauth version must be pinned explicitly. API-breaking changes in jwtauth require token-engine updates.
+- The adapter layer (`LibraryLoggerAdapter`, `LibraryOtelTracer`, `LibraryPrometheusMetrics`) must be maintained when jwtauth's interfaces change.
+- Error sentinel package ownership must be verified against the specific jwtauth version in use — sentinel package assignments changed between jwtauth v0.6.0 and v0.7.0.
+
+## Known Version Constraints
+
+| Dependency | Pinned Version | Reason |
+|---|---|---|
+| `github.com/aetomala/jwtauth` | v0.7.0 | Sentinel package layout (v0.7.0 specific) |
+| `go.uber.org/mock` | v0.6.0 | Required by jwtauth v0.7.0 |
+| `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` | v0.52.0 | v0.60.0+ dropped `UnaryServerInterceptor`; incompatible with `ChainUnaryInterceptor` pattern |
+
+## References
+
+- [internal/observability/errors.go](../../internal/observability/errors.go) — MapLibraryError sentinel table
+- [jwtauth SECURITY.md](https://github.com/aetomala/jwtauth/blob/main/SECURITY.md)
+- [jwtauth ADR directory](https://github.com/aetomala/jwtauth/tree/main/doc/adr)

--- a/doc/adr/ADR-003-static-caller-keys-v01.md
+++ b/doc/adr/ADR-003-static-caller-keys-v01.md
@@ -1,0 +1,44 @@
+# ADR-003: Static Caller Keys for v0.1
+
+**Status:** Accepted  
+**Date:** 2026-05-26
+
+## Context
+
+token-engine needs to authenticate callers — services that send gRPC requests. Authentication serves two purposes: identity establishment (which caller is this?) and access control (is this caller allowed to operate on this tenant?).
+
+Options evaluated:
+1. Static API key → caller identity map, configured at startup via environment variable
+2. Dynamic caller registry backed by Redis, allowing key rotation without restart
+3. mTLS client certificates with certificate identity extraction
+
+## Decision
+
+Static API key → caller identity map for v0.1. Keys are configured via `TOKEN_ENGINE_STATIC_CALLER_KEYS` at startup. The `StaticKeyAuthenticator` holds the map in memory and performs constant-time lookup on every request.
+
+## Rationale
+
+- **Simplicity over flexibility for v0.1.** The service needs to be runnable without Redis. A static map is sufficient for environments where key rotation can tolerate a restart.
+- **Interface seam preserved.** The `Authenticator` interface abstracts the lookup. Swapping the static implementation for a Redis-backed one in v0.2 requires no changes to the interceptor.
+- **Constant-time comparison.** API key comparison uses `subtle.ConstantTimeCompare` to prevent timing attacks — the static implementation has the same security property as a dynamic one.
+
+## Consequences
+
+**Positive:**
+- Zero external dependencies in v0.1 — service runs without Redis or a key management service.
+- Simple to reason about: the caller identity for any API key is determined at startup and does not change at runtime.
+
+**Negative:**
+- Key rotation requires a process restart with updated `TOKEN_ENGINE_STATIC_CALLER_KEYS`.
+- Key revocation is not immediate — the service must be restarted to revoke a key.
+- Static keys stored in environment variables require secrets management discipline at the deployment layer (Kubernetes Secrets, Vault agent injection, etc.).
+
+## Target Version
+
+v0.2 will introduce a Redis-backed `CallerRegistry` that supports key rotation without restart and immediate revocation.
+
+## References
+
+- [internal/interceptor/auth.go](../../internal/interceptor/auth.go) — StaticKeyAuthenticator
+- [internal/registry/caller.go](../../internal/registry/caller.go) — StaticCallerRegistry
+- [ADR-006](ADR-006-interceptor-chain-order.md) — where in the chain authentication runs

--- a/doc/adr/ADR-004-noop-stubs-v01.md
+++ b/doc/adr/ADR-004-noop-stubs-v01.md
@@ -1,0 +1,46 @@
+# ADR-004: NoOp Stubs for v0.1
+
+**Status:** Accepted  
+**Date:** 2026-05-26
+
+## Context
+
+Several planned components require Redis to be useful: audit logging (persist a record of every token operation), token reconciliation (periodically clean up expired or orphaned tokens), and the dynamic tenant registry. Redis is out of scope for v0.1.
+
+Two approaches were considered:
+1. Omit these components entirely and wire them in later.
+2. Define interfaces and NoOp implementations now; wire the real implementations later.
+
+## Decision
+
+Define interfaces and NoOp implementations for all three components. Wire the NoOp implementations in `main.go` for v0.1. The real implementations are added in v0.2 by replacing the NoOp with the Redis-backed version at the wiring site — no other files change.
+
+## Rationale
+
+- **Seam-first design.** Defining the interface now prevents future API churn. If the `AuditStore` interface is not defined until v0.2, adding it requires threading a new parameter through every constructor that needs it — a much larger change than swapping a NoOp for a real implementation.
+- **Tests can stub.** With an interface defined, test suites for other components can inject a mock `AuditStore` and verify the correct calls are made, even before the real implementation exists.
+- **No behavior change.** A NoOp that returns `nil` on every call is indistinguishable from no component at all, except it satisfies the interface. The service runs correctly in v0.1 without audit records or reconciliation.
+
+## Components
+
+| Interface | NoOp | Behavior |
+|---|---|---|
+| `audit.AuditStore` | `NoOpAuditStore` | `RecordRevocation` and `Ping` always return `nil` |
+| `reconciliation.TokenReconciler` | `NoOpReconciler` | `Run` returns `nil` immediately (does not block; does not respect context cancellation) |
+| `registry.TenantRegistry` | `StaticTenantRegistry` | Returns `codes.Unimplemented` for all methods — tenant lookup is handled via static caller registry in v0.1 |
+
+## Consequences
+
+**Positive:**
+- v0.2 implementation is a drop-in replacement — only `main.go` changes.
+- Test coverage of the interface contract is possible in v0.1.
+
+**Negative:**
+- No audit trail in v0.1 — token operations are not recorded anywhere beyond log lines.
+- No automatic cleanup of expired tokens in v0.1 — orphaned refresh tokens accumulate in the jwtauth `RefreshStore` until it is restarted or the store is manually cleared.
+
+## References
+
+- [internal/audit/store.go](../../internal/audit/store.go)
+- [internal/reconciliation/reconciler.go](../../internal/reconciliation/reconciler.go)
+- [internal/registry/tenant.go](../../internal/registry/tenant.go)

--- a/doc/adr/ADR-005-in-memory-idempotency-v01.md
+++ b/doc/adr/ADR-005-in-memory-idempotency-v01.md
@@ -1,0 +1,35 @@
+# ADR-005: In-Memory Idempotency Store for v0.1
+
+**Status:** Accepted  
+**Date:** 2026-05-26
+
+## Context
+
+`IssueToken` and `RefreshToken` operations must support idempotent execution: a caller that sends the same request twice (due to a network retry) should receive the same response without a second token issuance. This requires storing the response for a given idempotency key for some TTL.
+
+Durable idempotency (surviving restarts, shared across replicas) requires Redis. Redis is out of scope for v0.1.
+
+## Decision
+
+In-memory idempotency store with configurable TTL (`TOKEN_ENGINE_IDEMPOTENCY_TTL`, default 5 minutes). The store is a `sync.Map` with a background goroutine that sweeps expired entries.
+
+## Rationale
+
+- **Request deduplication works within the TTL window.** The primary use case for idempotency is network retries — a caller retries within seconds of the original request. An in-memory store with a 5-minute TTL covers this case correctly.
+- **Interface seam.** The `IdempotencyStore` interface is defined. v0.2 replaces the in-memory implementation with a Redis-backed one. No other code changes.
+- **Acceptable limitation.** The in-memory store is per-process. In a multi-replica deployment, a retry routed to a different replica will not find the cached response and will issue a second token pair. This is documented as a known limitation.
+
+## Limitations
+
+- **Not durable.** Idempotency state is lost on process restart. A retry arriving after a restart will issue a new token pair.
+- **Not shared across replicas.** In a multi-replica deployment, sticky sessions or a Redis-backed store (v0.2) are required for cross-replica idempotency.
+- **Memory-bound.** High-volume deployments with large TTLs accumulate idempotency entries in memory until the sweep goroutine clears them.
+
+## Target Version
+
+v0.2 replaces the in-memory store with a Redis-backed implementation that provides durability and cross-replica consistency.
+
+## References
+
+- [internal/store/idempotency.go](../../internal/store/idempotency.go)
+- [internal/interceptor/idempotency.go](../../internal/interceptor/idempotency.go)

--- a/doc/adr/ADR-006-interceptor-chain-order.md
+++ b/doc/adr/ADR-006-interceptor-chain-order.md
@@ -1,0 +1,52 @@
+# ADR-006: Interceptor Chain Order
+
+**Status:** Accepted  
+**Date:** 2026-05-26
+
+## Context
+
+Six cross-cutting concerns must be applied to every gRPC request: distributed tracing, correlation ID injection, API key authentication, caller authorization, request idempotency, and request validation. gRPC's `ChainUnaryInterceptor` applies them in order. The ordering has correctness, performance, and observability implications.
+
+## Decision
+
+The chain runs in this order:
+
+```
+1. OTel tracing
+2. Correlation ID
+3. Authentication
+4. Caller authorization
+5. Idempotency
+6. Validation
+```
+
+## Rationale
+
+**OTel first:** The trace span must be started before any other interceptor so that all downstream work — including authentication failures, log lines, and the handler — is attributed to the same trace. Span creation inside the OTel interceptor attaches the trace context to the `context.Context` that all subsequent interceptors receive.
+
+**Correlation ID second:** The correlation ID (a UUID) should be in the context before authentication so that auth failure log lines include the correlation ID. This makes it possible to correlate a rejected request across log aggregators without a trace ID.
+
+**Authentication before authorization:** Identity must be established before permissions can be checked. An unauthenticated request cannot be authorized.
+
+**Authorization before idempotency:** Checking the idempotency store for an unauthorized caller is wasted work and could leak information about whether a previous request with that key was successful. Authorization gates access to the idempotency store.
+
+**Idempotency before validation:** A duplicate request (same idempotency key within TTL) should return the cached response immediately, before field validation runs. Validation is not needed for a request that will return an already-computed result.
+
+**Validation last:** Only requests that have passed identity checks and idempotency deduplication reach the validation step. This minimizes unnecessary parsing work and keeps the validation interceptor focused purely on business logic preconditions.
+
+## Consequences
+
+**Positive:**
+- Unauthorized requests are rejected before any store access or business logic.
+- All log lines for a request share a correlation ID, including auth failure lines.
+- All request work appears under a single trace span.
+- Duplicate requests return immediately without hitting the handler.
+
+**Negative:**
+- OTel interceptor runs even for requests that fail authentication — a small overhead. This is intentional: failed auth requests are worth tracing for security monitoring.
+
+## References
+
+- [internal/interceptor/](../../internal/interceptor/)
+- [cmd/token-engine/main.go](../../cmd/token-engine/main.go) — chain assembly
+- [ARCHITECTURE.md — Interceptor Chain](../ARCHITECTURE.md#interceptor-chain)

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records
+
+| ADR | Title | Status | Date |
+|---|---|---|---|
+| [ADR-001](ADR-001-grpc-first-transport.md) | gRPC-First Transport | Accepted | 2026-05-26 |
+| [ADR-002](ADR-002-jwtauth-library-delegation.md) | jwtauth Library Delegation | Accepted | 2026-05-26 |
+| [ADR-003](ADR-003-static-caller-keys-v01.md) | Static Caller Keys for v0.1 | Accepted | 2026-05-26 |
+| [ADR-004](ADR-004-noop-stubs-v01.md) | NoOp Stubs for v0.1 | Accepted | 2026-05-26 |
+| [ADR-005](ADR-005-in-memory-idempotency-v01.md) | In-Memory Idempotency Store for v0.1 | Accepted | 2026-05-26 |
+| [ADR-006](ADR-006-interceptor-chain-order.md) | Interceptor Chain Order | Accepted | 2026-05-26 |

--- a/run-ci-locally.sh
+++ b/run-ci-locally.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Reproduces the full CI pipeline locally.
+# Exit code: 0 if all steps pass, 1 if any step fails.
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+FAILURES=0
+
+run_step() {
+    local name="$1"
+    shift
+    echo -e "${YELLOW}>>> ${name}${NC}"
+    if "$@"; then
+        echo -e "${GREEN}PASS: ${name}${NC}\n"
+    else
+        echo -e "${RED}FAIL: ${name}${NC}\n"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+run_step "go vet"         go vet ./...
+run_step "golangci-lint"  golangci-lint run ./...
+run_step "govulncheck"    govulncheck ./...
+run_step "go build"       go build ./...
+run_step "buf lint"       buf lint
+run_step "tests (race)"   ginkgo -r --race ./internal/...
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo -e "${RED}${FAILURES} step(s) failed.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}All steps passed.${NC}"


### PR DESCRIPTION
## Summary

- Full README with API reference, configuration table, observability, development guide, and roadmap
- CHANGELOG with `[Unreleased]` placeholder (v0.1 content added in implementation PR)
- CONTRIBUTING and SECURITY policies
- Makefile with `build`, `test`, `coverage`, `lint`, `proto-gen`, `ci`, `clean` targets
- `run-ci-locally.sh` — reproduces full CI pipeline locally with color-coded output
- `.gitignore` — excludes binary, coverage files
- `.github/workflows/ci.yml` — two-job CI: Lint (`go vet`, `golangci-lint`, `govulncheck`) and Test (`go build`, `buf lint`, `ginkgo -r --race`)
- GitHub issue templates and PR template
- `doc/ARCHITECTURE.md` — component model, interceptor chain diagram, request lifecycle, jwtauth integration, package layout, roadmap
- `doc/DEPLOYMENT.md` — operational reference: health probes, Prometheus scrape config, OTel setup, graceful shutdown, Redis notes
- `doc/METRICS.md` — all 5 Prometheus metrics with PromQL examples and alerting rules
- `doc/adr/` — 6 ADRs: gRPC transport, jwtauth delegation, static auth, NoOp stubs, in-memory idempotency, interceptor chain order

## Test Plan

- [ ] CI passes on this branch (no Go source yet — lint/build are no-ops; expected)
- [ ] All documentation files present and non-trivial
- [ ] `.gitignore` excludes binary and coverage files

## Notes

No Go source is present in this branch — that comes in the v0.1 implementation PR after this merges. CI lint/build steps will be no-ops until then.