### PR TITLE
docs: expand roadmap to include v0.3–v0.5 milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,11 @@ Architecture decisions are recorded in [doc/adr/](doc/adr/).
 | Version | Status | Key Additions |
 |---|---|---|
 | v0.1 | ✅ Complete | gRPC service, interceptor chain, static auth, in-memory idempotency, NoOp audit + reconciliation |
-| v0.2 | Planned | Redis-backed idempotency store, audit logging, token reconciliation, dynamic tenant registry |
-| v1.0 | Planned | Stable API commitment, multi-region deployment docs, dynamic caller registry |
+| v0.2 | Planned | Single hardcoded tenant, Redis key + refresh stores, `IssueToken` + `RefreshToken` live |
+| v0.3 | Planned | `RevokeToken`, `RevokeAllForAudience`, `RevokeAllUserTokens`, JWKS endpoint, Redis audit store |
+| v0.4 | Planned | Redis idempotency store, idempotency interceptor wired, `RefreshToken` retry safety end-to-end |
+| v0.5 | Planned | mTLS authenticator, static YAML caller registry, full multi-tenant `TenantRegistry` |
+| v1.0 | Planned | Distributed locks, cursor-based reconciler, Kubernetes manifests, operator runbook |
 
 ---
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -193,9 +193,12 @@ Mocks are generated with `go.uber.org/mock/mockgen` in source mode. All mocks li
 
 | Version | Target | Key Work |
 |---|---|---|
-| v0.1 | ✅ Complete | Full service skeleton, static auth, in-memory idempotency, NoOp stubs |
-| v0.2 | Planned | Redis client lifecycle, Redis-backed idempotency + audit + reconciliation, dynamic tenant registry |
-| v1.0 | Planned | Stable API commitment, dynamic caller registry, multi-region deployment guide |
+| v0.1 | ✅ Complete | Service skeleton, static auth, in-memory idempotency, NoOp stubs for all deferred concerns |
+| v0.2 | Planned | Single hardcoded tenant, Redis key + refresh stores, `tokens.Manager` wired, `IssueToken` + `RefreshToken` live |
+| v0.3 | Planned | `RevokeToken`, `RevokeAllForAudience`, `RevokeAllUserTokens` handlers, JWKS endpoint, Redis audit store |
+| v0.4 | Planned | Redis idempotency store, idempotency interceptor wired, `RefreshToken` retry safety verified end-to-end |
+| v0.5 | Planned | mTLS authenticator, static YAML caller registry, full multi-tenant `TenantRegistry` with drain/remove lifecycle |
+| v1.0 | Planned | Distributed locks for key rotation + reconciliation, cursor-based reconciler, Kubernetes manifests, operator runbook |
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands the roadmap table in both `README.md` and `doc/ARCHITECTURE.md` from 3 rows (v0.1, v0.2, v1.0) to 6 rows covering all planned pre-v1.0 milestones
- v0.3: revocation handlers + JWKS endpoint + Redis audit store
- v0.4: Redis idempotency store + idempotency interceptor wired
- v0.5: mTLS authenticator + static YAML caller registry + full multi-tenant TenantRegistry
- v0.2 description corrected to match actual scope (first working RPCs, not idempotency/audit)

## Test plan

- [ ] Verify roadmap rows in README.md match doc/ARCHITECTURE.md
- [ ] Confirm CI passes (docs-only change, no Go files touched)