### PR TITLE
feat(v0.2): phases 9A–9D — v0.2 test suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -36,6 +37,7 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/redis/go-redis/v9 v9.19.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aetomala/jwtauth v0.7.0 h1:+HgxfX6waJMEZGtLGPsyrW37l3Q1v1gXZwwTVhoTim
 github.com/aetomala/jwtauth v0.7.0/go.mod h1:HtZVSd5ytJhEY61oz2Otss0ZGebXWnM38kZNzDNHXU4=
 github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
 github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/internal/handler/handler_suite_test.go
+++ b/internal/handler/handler_suite_test.go
@@ -1,0 +1,13 @@
+package handler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handler Suite")
+}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,0 +1,479 @@
+package handler_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"time"
+
+	tokenv1 "github.com/aetomala/token-engine/gen/v1"
+	"github.com/aetomala/token-engine/internal/handler"
+	obs "github.com/aetomala/token-engine/internal/observability"
+	"github.com/aetomala/token-engine/internal/testutil"
+	"github.com/aetomala/jwtauth/pkg/keys"
+	"github.com/aetomala/jwtauth/pkg/storage"
+	"github.com/aetomala/jwtauth/pkg/tokens"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// buildRealManager creates a started tokens.Manager backed by an in-memory store
+// and the given MockKeyManager. It sets mock expectations for the Start and
+// Shutdown lifecycle calls that tokens.Manager delegates to the KeyManager.
+// Shutdown is registered via DeferCleanup.
+func buildRealManager(ctrl *gomock.Controller, mockKM *testutil.MockKeyManager) *tokens.Manager {
+	memStore := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
+	manager, err := tokens.NewManager(tokens.TokenManagerConfig{
+		KeyManager:   mockKM,
+		RefreshStore: memStore,
+		Namespace:    "test",
+		Issuer:       "test-issuer",
+		Audience:     []string{"api"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	mockKM.EXPECT().Start(gomock.Any()).Return(nil)
+	mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).AnyTimes()
+	Expect(manager.Start(context.Background())).NotTo(HaveOccurred())
+	DeferCleanup(func() { _ = manager.Shutdown(context.Background()) })
+	return manager
+}
+
+// ===== Phase 3: IssueToken =====
+
+var _ = Describe("Phase 3: TokenHandler — IssueToken", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		ctrl       *gomock.Controller
+		mockReg    *testutil.MockTenantRegistry
+		mockLogger *testutil.MockLogger
+		privateKey *rsa.PrivateKey
+		h          *handler.TokenHandler
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockLogger = testutil.NewMockLogger(ctrl)
+
+		var err error
+		privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+
+		h = handler.NewTokenHandler(mockReg, mockLogger, obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when TenantRegistry.Get returns the Manager", func() {
+		It("calls IssueTokenPairWithClaims and returns access_token and refresh_token", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			req := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			resp, err := h.IssueToken(ctx, req)
+
+			Expect(err).To(BeNil())
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.AccessToken).NotTo(BeEmpty())
+			Expect(resp.RefreshToken).NotTo(BeEmpty())
+		})
+
+		It("passes WithAudience option when req.Audiences is non-empty", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			req := &tokenv1.IssueTokenRequest{
+				Sub:       "user1",
+				TenantId:  "test-tenant",
+				Audiences: []string{"api", "admin"},
+			}
+			resp, err := h.IssueToken(ctx, req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.AccessToken).NotTo(BeEmpty())
+		})
+
+		It("passes no WithAudience option when req.Audiences is empty", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			req := &tokenv1.IssueTokenRequest{
+				Sub:       "user1",
+				TenantId:  "test-tenant",
+				Audiences: []string{},
+			}
+			resp, err := h.IssueToken(ctx, req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.AccessToken).NotTo(BeEmpty())
+		})
+
+		It("converts req.Claims map[string]string to tokens.CustomClaims", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			req := &tokenv1.IssueTokenRequest{
+				Sub:      "user1",
+				TenantId: "test-tenant",
+				Claims:   map[string]string{"role": "admin", "org": "acme"},
+			}
+			resp, err := h.IssueToken(ctx, req)
+
+			Expect(err).To(BeNil())
+			Expect(resp.AccessToken).NotTo(BeEmpty())
+		})
+	})
+
+	Context("when TenantRegistry.Get returns codes.NotFound", func() {
+		It("returns codes.NotFound without calling the library", func() {
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(nil, status.Error(codes.NotFound, "tenant not found"))
+
+			req := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			_, err := h.IssueToken(ctx, req)
+
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+	})
+
+	Context("when TenantRegistry.Get returns codes.InvalidArgument", func() {
+		It("returns codes.InvalidArgument without calling the library", func() {
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(nil, status.Error(codes.InvalidArgument, "invalid tenant_id"))
+
+			req := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			_, err := h.IssueToken(ctx, req)
+
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		})
+	})
+
+	Context("when IssueTokenPairWithClaims returns a library error", func() {
+		It("maps the error via MapLibraryError and returns the mapped gRPC status", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			// GetCurrentSigningKey fails — causes IssueTokenPairWithClaims to fail
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(nil, "", keys.ErrManagerNotRunning).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			req := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			_, err := h.IssueToken(ctx, req)
+
+			Expect(err).NotTo(BeNil())
+			// ErrManagerNotRunning is not a mapped sentinel → codes.Internal
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+		})
+	})
+})
+
+// ===== Phase 3: RefreshToken =====
+
+var _ = Describe("Phase 3: TokenHandler — RefreshToken", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		ctrl       *gomock.Controller
+		mockReg    *testutil.MockTenantRegistry
+		mockLogger *testutil.MockLogger
+		privateKey *rsa.PrivateKey
+		h          *handler.TokenHandler
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockLogger = testutil.NewMockLogger(ctrl)
+
+		var err error
+		privateKey, err = rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).NotTo(HaveOccurred())
+
+		h = handler.NewTokenHandler(mockReg, mockLogger, obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when TenantRegistry.Get returns the Manager and token is valid", func() {
+		It("calls RefreshAccessTokenWithClaims and returns access_token", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			// Issue a real token pair first
+			issueReq := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+			issueResp, err := h.IssueToken(ctx, issueReq)
+			Expect(err).To(BeNil())
+			Expect(issueResp.RefreshToken).NotTo(BeEmpty())
+
+			// Now refresh
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+			refreshReq := &tokenv1.RefreshTokenRequest{
+				RefreshToken: issueResp.RefreshToken,
+				TenantId:     "test-tenant",
+			}
+			resp, err := h.RefreshToken(ctx, refreshReq)
+
+			Expect(err).To(BeNil())
+			Expect(resp).NotTo(BeNil())
+			Expect(resp.AccessToken).NotTo(BeEmpty())
+		})
+	})
+
+	Context("when refresh token is revoked", func() {
+		It("returns codes.PermissionDenied", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().Start(gomock.Any()).Return(nil)
+			mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).AnyTimes()
+			memStore := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
+			manager, err := tokens.NewManager(tokens.TokenManagerConfig{
+				KeyManager:   mockKM,
+				RefreshStore: memStore,
+				Namespace:    "test",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(manager.Start(context.Background())).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = manager.Shutdown(context.Background()) })
+
+			// Issue a token pair to get a valid refresh token
+			issueReq := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+			issueResp, err := h.IssueToken(ctx, issueReq)
+			Expect(err).To(BeNil())
+			refreshToken := issueResp.RefreshToken
+
+			// Revoke the refresh token via the manager
+			revokeErr := manager.RevokeRefreshToken(ctx, refreshToken)
+			Expect(revokeErr).To(BeNil())
+
+			// Now refresh — should get PermissionDenied
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+			refreshReq := &tokenv1.RefreshTokenRequest{
+				RefreshToken: refreshToken,
+				TenantId:     "test-tenant",
+			}
+			_, err = h.RefreshToken(ctx, refreshReq)
+
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+		})
+	})
+
+	Context("when refresh token is not in the store", func() {
+		It("returns a non-OK status", func() {
+			mockKM := testutil.NewMockKeyManager(ctrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(ctrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			refreshReq := &tokenv1.RefreshTokenRequest{
+				RefreshToken: "non-existent-token-id",
+				TenantId:     "test-tenant",
+			}
+			_, err := h.RefreshToken(ctx, refreshReq)
+
+			Expect(err).NotTo(BeNil())
+			// The manager maps unknown tokens to ErrInvalidRefreshToken → codes.Internal
+			Expect(status.Code(err)).NotTo(Equal(codes.OK))
+		})
+	})
+
+	Context("when TenantRegistry.Get returns an error", func() {
+		It("returns the registry error without calling the library", func() {
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(nil, status.Error(codes.Unauthenticated, "token expired"))
+
+			refreshReq := &tokenv1.RefreshTokenRequest{
+				RefreshToken: "some-token",
+				TenantId:     "test-tenant",
+			}
+			_, err := h.RefreshToken(ctx, refreshReq)
+
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+		})
+	})
+})
+
+// ===== Phase 4: Observability =====
+
+var _ = Describe("Phase 4: TokenHandler — observability", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		ctrl       *gomock.Controller
+		mockReg    *testutil.MockTenantRegistry
+		mockTracer *testutil.MockTracer
+		mockSpan   *testutil.MockSpan
+		h          *handler.TokenHandler
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockTracer = testutil.NewMockTracer(ctrl)
+		mockSpan = testutil.NewMockSpan(ctrl)
+		h = handler.NewTokenHandler(mockReg, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("IssueToken — span lifecycle", func() {
+		It("opens and ends a span named 'IssueToken'", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).NotTo(HaveOccurred())
+
+			innerCtrl := gomock.NewController(GinkgoT())
+			defer innerCtrl.Finish()
+			mockKM := testutil.NewMockKeyManager(innerCtrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			manager := buildRealManager(innerCtrl, mockKM)
+
+			mockTracer.EXPECT().Start(gomock.Any(), "IssueToken").Return(ctx, mockSpan)
+			mockSpan.EXPECT().SetStatus(obs.StatusOK, "")
+			mockSpan.EXPECT().End()
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+
+			req := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			_, err = h.IssueToken(ctx, req)
+			Expect(err).To(BeNil())
+		})
+
+		It("records error on span when handler returns non-nil error", func() {
+			mockTracer.EXPECT().Start(gomock.Any(), "IssueToken").Return(ctx, mockSpan)
+			mockSpan.EXPECT().RecordError(gomock.Any())
+			mockSpan.EXPECT().SetStatus(obs.StatusError, gomock.Any())
+			mockSpan.EXPECT().End()
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(nil, status.Error(codes.NotFound, "not found"))
+
+			req := &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"}
+			_, err := h.IssueToken(ctx, req)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("RefreshToken — span lifecycle", func() {
+		It("opens and ends a span named 'RefreshToken'", func() {
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).NotTo(HaveOccurred())
+
+			innerCtrl := gomock.NewController(GinkgoT())
+			defer innerCtrl.Finish()
+			mockKM := testutil.NewMockKeyManager(innerCtrl)
+			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			// Need to issue a token first using a handler with NoOpTracer
+			hNoOp := handler.NewTokenHandler(mockReg, obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+			manager := buildRealManager(innerCtrl, mockKM)
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+			issueResp, err := hNoOp.IssueToken(ctx, &tokenv1.IssueTokenRequest{Sub: "user1", TenantId: "test-tenant"})
+			Expect(err).To(BeNil())
+
+			// Now use the MockTracer handler for the refresh
+			mockTracer.EXPECT().Start(gomock.Any(), "RefreshToken").Return(ctx, mockSpan)
+			mockSpan.EXPECT().SetStatus(obs.StatusOK, "")
+			mockSpan.EXPECT().End()
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
+			_, err = h.RefreshToken(ctx, &tokenv1.RefreshTokenRequest{
+				RefreshToken: issueResp.RefreshToken,
+				TenantId:     "test-tenant",
+			})
+			Expect(err).To(BeNil())
+		})
+
+		It("records error on span when handler returns non-nil error", func() {
+			mockTracer.EXPECT().Start(gomock.Any(), "RefreshToken").Return(ctx, mockSpan)
+			mockSpan.EXPECT().RecordError(gomock.Any())
+			mockSpan.EXPECT().SetStatus(obs.StatusError, gomock.Any())
+			mockSpan.EXPECT().End()
+
+			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(nil, status.Error(codes.Unauthenticated, "expired"))
+
+			_, err := h.RefreshToken(ctx, &tokenv1.RefreshTokenRequest{
+				RefreshToken: "some-token",
+				TenantId:     "test-tenant",
+			})
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})
+
+// ===== Phase 3: Unimplemented RPCs =====
+
+var _ = Describe("Phase 3: TokenHandler — unimplemented RPCs", func() {
+	var (
+		ctx  context.Context
+		cancel context.CancelFunc
+		ctrl *gomock.Controller
+		h    *handler.TokenHandler
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg := testutil.NewMockTenantRegistry(ctrl)
+		h = handler.NewTokenHandler(mockReg, obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("RevokeToken", func() {
+		It("returns codes.Unimplemented", func() {
+			_, err := h.RevokeToken(ctx, &tokenv1.RevokeTokenRequest{})
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unimplemented))
+		})
+	})
+
+	Context("RevokeAllForAudience", func() {
+		It("returns codes.Unimplemented", func() {
+			_, err := h.RevokeAllForAudience(ctx, &tokenv1.RevokeAudienceRequest{})
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unimplemented))
+		})
+	})
+
+	Context("RevokeAllUserTokens", func() {
+		It("returns codes.Unimplemented", func() {
+			_, err := h.RevokeAllUserTokens(ctx, &tokenv1.RevokeUserRequest{})
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unimplemented))
+		})
+	})
+})

--- a/internal/health/v02_test.go
+++ b/internal/health/v02_test.go
@@ -1,0 +1,123 @@
+package health_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/aetomala/jwtauth/pkg/keys"
+	"github.com/aetomala/token-engine/internal/health"
+	"github.com/aetomala/token-engine/internal/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Phase 3: RedisChecker", func() {
+	var (
+		ctrl *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("Name()", func() {
+		It("returns 'redis'", func() {
+			checker := health.NewRedisChecker(nil)
+			Expect(checker.Name()).To(Equal(health.CheckerNameRedis))
+		})
+	})
+
+	Context("when Redis PING succeeds", func() {
+		It("returns nil", func() {
+			mr, err := miniredis.Run()
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(mr.Close)
+
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			checker := health.NewRedisChecker(client)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			Expect(checker.Check(ctx)).To(BeNil())
+		})
+	})
+
+	Context("when Redis PING fails", func() {
+		It("returns a non-nil error", func() {
+			client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+			checker := health.NewRedisChecker(client)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+
+			Expect(checker.Check(ctx)).NotTo(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Phase 3: KeyAvailabilityChecker", func() {
+	var (
+		ctrl   *gomock.Controller
+		mockKM *testutil.MockKeyManager
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockKM = testutil.NewMockKeyManager(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("Name()", func() {
+		It("returns 'key_availability'", func() {
+			checker := health.NewKeyAvailabilityChecker(mockKM)
+			Expect(checker.Name()).To(Equal(health.CheckerNameKeyAvailability))
+		})
+	})
+
+	Context("when GetAllKeyInfo returns a non-empty slice", func() {
+		It("returns nil", func() {
+			checker := health.NewKeyAvailabilityChecker(mockKM)
+			mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return([]keys.KeyInfo{{KeyID: "key1"}}, nil)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			Expect(checker.Check(ctx)).To(BeNil())
+		})
+	})
+
+	Context("when GetAllKeyInfo returns an empty slice", func() {
+		It("returns a non-nil error", func() {
+			checker := health.NewKeyAvailabilityChecker(mockKM)
+			mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return([]keys.KeyInfo{}, nil)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			Expect(checker.Check(ctx)).NotTo(BeNil())
+		})
+	})
+
+	Context("when GetAllKeyInfo returns an error", func() {
+		It("returns a non-nil error", func() {
+			checker := health.NewKeyAvailabilityChecker(mockKM)
+			mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return(nil, keys.ErrManagerNotRunning)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			Expect(checker.Check(ctx)).NotTo(BeNil())
+		})
+	})
+})

--- a/internal/interceptor/v02_test.go
+++ b/internal/interceptor/v02_test.go
@@ -1,0 +1,325 @@
+package interceptor_test
+
+import (
+	"context"
+	"time"
+
+	tokenv1 "github.com/aetomala/token-engine/gen/v1"
+	"github.com/aetomala/token-engine/internal/interceptor"
+	obs "github.com/aetomala/token-engine/internal/observability"
+	"github.com/aetomala/token-engine/internal/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// ===== ValidationInterceptor — v0.2 =====
+
+var _ = Describe("Phase 3: ValidationInterceptor", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		ctrl       *gomock.Controller
+		mockLogger *testutil.MockLogger
+		sut        grpc.UnaryServerInterceptor
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockLogger = testutil.NewMockLogger(ctrl)
+		sut = interceptor.NewValidationInterceptor(mockLogger)
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("IssueTokenRequest with empty sub", func() {
+		It("returns codes.InvalidArgument without calling the handler", func() {
+			req := &tokenv1.IssueTokenRequest{Sub: "", TenantId: "t1"}
+			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+			handlerCalled := false
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return nil, nil
+			}
+
+			_, err := sut(ctx, req, info, handler)
+
+			Expect(handlerCalled).To(BeFalse())
+			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		})
+	})
+
+	Context("IssueTokenRequest with reserved claim key", func() {
+		issueInfo := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+
+		for _, key := range []string{"sub", "iss", "aud", "exp", "iat", "nbf", "jti"} {
+			key := key
+			It("returns codes.InvalidArgument naming the offending key — '"+key+"'", func() {
+				req := &tokenv1.IssueTokenRequest{
+					Sub:    "user1",
+					Claims: map[string]string{key: "value"},
+				}
+				handlerCalled := false
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					handlerCalled = true
+					return nil, nil
+				}
+
+				_, err := sut(ctx, req, issueInfo, handler)
+
+				Expect(handlerCalled).To(BeFalse())
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+				Expect(err.Error()).To(ContainSubstring(`"` + key + `"`))
+			})
+		}
+
+		It("does not call the handler", func() {
+			req := &tokenv1.IssueTokenRequest{
+				Sub:    "user1",
+				Claims: map[string]string{"sub": "bad"},
+			}
+			handlerCalled := false
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return nil, nil
+			}
+
+			_, _ = sut(ctx, req, issueInfo, handler)
+
+			Expect(handlerCalled).To(BeFalse())
+		})
+	})
+
+	Context("RefreshTokenRequest with reserved claim key", func() {
+		It("returns codes.InvalidArgument naming the offending key", func() {
+			req := &tokenv1.RefreshTokenRequest{
+				RefreshToken: "tok",
+				Claims:       map[string]string{"exp": "bad"},
+			}
+			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_RefreshToken_FullMethodName}
+			handlerCalled := false
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return nil, nil
+			}
+
+			_, err := sut(ctx, req, info, handler)
+
+			Expect(handlerCalled).To(BeFalse())
+			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring(`"exp"`))
+		})
+
+		It("does not call the handler", func() {
+			req := &tokenv1.RefreshTokenRequest{
+				RefreshToken: "tok",
+				Claims:       map[string]string{"iss": "bad"},
+			}
+			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_RefreshToken_FullMethodName}
+			handlerCalled := false
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return nil, nil
+			}
+
+			_, _ = sut(ctx, req, info, handler)
+
+			Expect(handlerCalled).To(BeFalse())
+		})
+	})
+
+	Context("IssueTokenRequest with valid sub and no reserved keys", func() {
+		It("calls the handler and returns its response unchanged", func() {
+			req := &tokenv1.IssueTokenRequest{
+				Sub:    "user1",
+				Claims: map[string]string{"role": "admin"},
+			}
+			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+			expected := &tokenv1.TokenPair{AccessToken: "acc", RefreshToken: "ref"}
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return expected, nil
+			}
+
+			resp, err := sut(ctx, req, info, handler)
+
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(expected))
+		})
+	})
+
+	Context("RPC method that is not IssueToken or RefreshToken", func() {
+		It("calls the handler without inspecting the request", func() {
+			info := &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/RevokeToken"}
+			handlerCalled := false
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return "ok", nil
+			}
+
+			resp, err := sut(ctx, nil, info, handler)
+
+			Expect(handlerCalled).To(BeTrue())
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal("ok"))
+		})
+	})
+})
+
+// ===== CorrelationInterceptor — metric emission (from interceptor package) =====
+
+var _ = Describe("Phase 3: CorrelationInterceptor (interceptor perspective)", func() {
+	var (
+		ctx         context.Context
+		cancel      context.CancelFunc
+		ctrl        *gomock.Controller
+		mockMetrics *testutil.MockMetrics
+		mockLogger  *testutil.MockLogger
+		info        *grpc.UnaryServerInfo
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockMetrics = testutil.NewMockMetrics(ctrl)
+		mockLogger = testutil.NewMockLogger(ctrl)
+		info = &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("metric emission — success path", func() {
+		It("increments MetricGRPCRequests with rpc_method=info.FullMethod and status='OK'", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+				"status":     codes.OK.String(),
+			})
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+			})
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+
+		It("records MetricGRPCDuration with rpc_method=info.FullMethod", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+			})
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+	})
+
+	Context("metric emission — error path", func() {
+		It("increments MetricGRPCRequests with status matching the gRPC error code string", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.Error(codes.PermissionDenied, "denied")
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+				"status":     codes.PermissionDenied.String(),
+			})
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), gomock.Any())
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+
+		It("records MetricGRPCDuration even when handler returns error", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.Error(codes.Unavailable, "unavailable")
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+			})
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+	})
+
+	Context("correlation ID — absent from inbound metadata", func() {
+		It("generates a UUID v4 and binds it to ctx", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+
+			var capturedCtx context.Context
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				capturedCtx = ctx
+				return nil, nil
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+
+			id := obs.CorrelationIDFromContext(capturedCtx)
+			Expect(id).NotTo(BeEmpty())
+			Expect(len(id)).To(Equal(36)) // UUID v4
+		})
+
+		It("sets the correlation ID on the active OTel span as an attribute", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+
+			mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+
+			Expect(func() {
+				interceptorFn(ctxWithMeta, nil, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				})
+			}).NotTo(Panic())
+		})
+	})
+
+	Context("correlation ID — present in inbound metadata", func() {
+		It("extracts the existing ID and binds it to ctx without generating a new one", func() {
+			existingID := "fixed-existing-id"
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.Pairs(obs.MetadataKeyCorrelationID, existingID))
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+
+			var capturedCtx context.Context
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				capturedCtx = ctx
+				return nil, nil
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+
+			Expect(obs.CorrelationIDFromContext(capturedCtx)).To(Equal(existingID))
+		})
+	})
+})

--- a/internal/observability/v02_test.go
+++ b/internal/observability/v02_test.go
@@ -1,0 +1,181 @@
+package observability_test
+
+import (
+	"context"
+	"time"
+
+	librarymetrics "github.com/aetomala/jwtauth/pkg/metrics"
+	obs "github.com/aetomala/token-engine/internal/observability"
+	"github.com/aetomala/token-engine/internal/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// ===== LibraryPrometheusMetrics =====
+
+var _ = Describe("Phase 3: LibraryPrometheusMetrics", func() {
+	var (
+		ctx         context.Context
+		cancel      context.CancelFunc
+		ctrl        *gomock.Controller
+		mockInner   *testutil.MockMetrics
+		sut         *obs.LibraryPrometheusMetrics
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockInner = testutil.NewMockMetrics(ctrl)
+		sut = obs.NewLibraryPrometheusMetrics(mockInner)
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	_ = ctx // suppress unused warning in non-ctx tests
+
+	Context("satisfies librarymetrics.Metrics interface", func() {
+		It("compiles with var _ librarymetrics.Metrics = (*obs.LibraryPrometheusMetrics)(nil)", func() {
+			var _ librarymetrics.Metrics = (*obs.LibraryPrometheusMetrics)(nil)
+			Expect(true).To(BeTrue())
+		})
+	})
+
+	Context("each method delegates to inner without transformation", func() {
+		It("IncrementCounter delegates to inner with exact args", func() {
+			labels := map[string]string{"key": "val"}
+			mockInner.EXPECT().IncrementCounter("some_metric", labels)
+
+			sut.IncrementCounter("some_metric", labels)
+		})
+
+		It("AddCounter delegates to inner with exact args", func() {
+			labels := map[string]string{"k": "v"}
+			mockInner.EXPECT().AddCounter("some_counter", 3.14, labels)
+
+			sut.AddCounter("some_counter", 3.14, labels)
+		})
+
+		It("SetGauge delegates to inner with exact args", func() {
+			labels := map[string]string{"env": "test"}
+			mockInner.EXPECT().SetGauge("some_gauge", 42.0, labels)
+
+			sut.SetGauge("some_gauge", 42.0, labels)
+		})
+
+		It("RecordHistogram delegates to inner with exact args", func() {
+			labels := map[string]string{}
+			mockInner.EXPECT().RecordHistogram("some_histogram", 0.5, labels)
+
+			sut.RecordHistogram("some_histogram", 0.5, labels)
+		})
+
+		It("RecordDuration delegates to inner with exact args", func() {
+			labels := map[string]string{"rpc": "test"}
+			mockInner.EXPECT().RecordDuration("some_duration", 2*time.Second, labels)
+
+			sut.RecordDuration("some_duration", 2*time.Second, labels)
+		})
+	})
+})
+
+// ===== CorrelationInterceptor — metric emission =====
+
+var _ = Describe("Phase 3: CorrelationInterceptor — metric emission", func() {
+	var (
+		ctx         context.Context
+		cancel      context.CancelFunc
+		ctrl        *gomock.Controller
+		mockMetrics *testutil.MockMetrics
+		mockLogger  *testutil.MockLogger
+		info        *grpc.UnaryServerInfo
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockMetrics = testutil.NewMockMetrics(ctrl)
+		mockLogger = testutil.NewMockLogger(ctrl)
+		info = &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("success path", func() {
+		It("increments MetricGRPCRequests with rpc_method=info.FullMethod and status='OK'", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+				"rpc_method": "/test.Service/Method",
+				"status":     codes.OK.String(),
+			})
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+				"rpc_method": "/test.Service/Method",
+			})
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+
+		It("records MetricGRPCDuration with rpc_method=info.FullMethod", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+				"rpc_method": "/test.Service/Method",
+			})
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+	})
+
+	Context("error path", func() {
+		It("increments MetricGRPCRequests with status matching the gRPC error code string", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.Error(codes.NotFound, "not found")
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+				"rpc_method": "/test.Service/Method",
+				"status":     codes.NotFound.String(),
+			})
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), gomock.Any())
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+
+		It("records MetricGRPCDuration even when handler returns error", func() {
+			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.Error(codes.Internal, "oops")
+			}
+
+			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+				"rpc_method": "/test.Service/Method",
+			})
+
+			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		})
+	})
+})

--- a/internal/registry/v02_test.go
+++ b/internal/registry/v02_test.go
@@ -1,0 +1,107 @@
+package registry_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/aetomala/token-engine/internal/config"
+	"github.com/aetomala/token-engine/internal/observability"
+	"github.com/aetomala/token-engine/internal/registry"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ = Describe("Phase 3: StaticTenantRegistry", func() {
+	var (
+		ctx     context.Context
+		cancel  context.CancelFunc
+		mr      *miniredis.Miniredis
+		client  *redis.Client
+		cfg     *config.Config
+		promReg *prometheus.Registry
+		logger  observability.Logger
+		tracer  observability.Tracer
+		metrics observability.Metrics
+		reg     *registry.StaticTenantRegistry
+	)
+
+	BeforeEach(func() {
+		// Allow enough time for RSA key generation during Start.
+		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+
+		var err error
+		mr, err = miniredis.Run()
+		Expect(err).NotTo(HaveOccurred())
+
+		client = redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		cfg = &config.Config{Issuer: "test-tenant", Audience: "api"}
+		promReg = prometheus.NewRegistry()
+		logger = observability.NewNoOpLogger()
+		tracer = observability.NewNoOpTracer()
+		metrics = observability.NewNoOpMetrics()
+
+		reg, err = registry.NewStaticTenantRegistry(ctx, client, cfg, promReg, logger, tracer, metrics)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		cancel()
+		mr.Close()
+	})
+
+	Context("Get with empty string tenant_id", func() {
+		It("returns codes.InvalidArgument", func() {
+			_, err := reg.Get(ctx, "")
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		})
+	})
+
+	Context("Get with tenant_id matching cfg.Issuer", func() {
+		It("returns the Manager", func() {
+			manager, err := reg.Get(ctx, "test-tenant")
+			Expect(err).To(BeNil())
+			Expect(manager).NotTo(BeNil())
+		})
+
+		It("returns nil error", func() {
+			_, err := reg.Get(ctx, "test-tenant")
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Get with non-empty tenant_id not matching cfg.Issuer", func() {
+		It("returns codes.NotFound", func() {
+			_, err := reg.Get(ctx, "other-tenant")
+			Expect(err).NotTo(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+	})
+
+	Context("KeyManager()", func() {
+		It("returns a non-nil KeyManager", func() {
+			km := reg.KeyManager()
+			Expect(km).NotTo(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Phase 1: StaticTenantRegistry — constructor errors", func() {
+	Context("when redis client is nil", func() {
+		It("returns an error", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			cfg := &config.Config{Issuer: "test-tenant", Audience: "api"}
+			_, err := registry.NewStaticTenantRegistry(ctx, nil, cfg, prometheus.NewRegistry(),
+				observability.NewNoOpLogger(), observability.NewNoOpTracer(), observability.NewNoOpMetrics())
+
+			Expect(err).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- **9A**: `internal/observability` — `LibraryPrometheusMetrics` interface satisfaction + 5 delegation tests; `CorrelationInterceptor` metric emission (success + error paths). 100% coverage.
- **9B**: `internal/interceptor` — `ValidationInterceptor` (empty sub, 7 reserved keys, RefreshToken reserved key, valid pass-through, non-target method); `CorrelationInterceptor` metric + correlation-ID tests. 97.1% coverage.
- **9C**: `internal/health` — `RedisChecker` (Name, PING success via miniredis, PING failure); `KeyAvailabilityChecker` (Name, non-empty slice, empty slice, error from KeyManager). `internal/registry` — `StaticTenantRegistry` constructor errors, Get variants, KeyManager accessor. 100% / 82.6% coverage.
- **9D**: `internal/handler` — `TokenHandler` IssueToken (4 success cases, NotFound, InvalidArgument, library error mapping); RefreshToken (valid refresh, revoked token, unknown token, registry error); span lifecycle (open/close/error recording for both methods); unimplemented RPCs. 97.7% coverage.

## Corrections vs packets

- **9D**: `tokens.Manager.Start()` delegates to `KeyManager.Start()` — mock expectations required in `buildRealManager`. `tokens.Manager.Shutdown()` similarly delegates — `.AnyTimes()` expectation covers `DeferCleanup`.

## Test plan

- [x] `go test -race -count=1 ./internal/handler/...` — 18/18 PASS
- [x] `go test -race -count=1 ./internal/...` — all suites green, no DATA RACE
- [x] All coverage floors met: handler 97.7%, interceptor 97.1%, health 100%, registry 82.6%, observability 100%