### PR TITLE
feat(v0.3/phases-10abc): test suites for audit, health, config, and handler

### DIFF
--- a/internal/audit/slog_test.go
+++ b/internal/audit/slog_test.go
@@ -1,0 +1,117 @@
+package audit_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/aetomala/token-engine/internal/audit"
+	"github.com/aetomala/token-engine/internal/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Phase 1: SlogAuditStore — Constructor and Initialization", func() {
+	It("satisfies audit.Store interface", func() {
+		var _ audit.Store = (*audit.SlogAuditStore)(nil)
+		Expect(true).To(BeTrue())
+	})
+})
+
+var _ = Describe("Phase 3: SlogAuditStore — Core Operations", func() {
+	var (
+		ctx        context.Context
+		cancel     context.CancelFunc
+		ctrl       *gomock.Controller
+		mockLogger *testutil.MockLogger
+		store      *audit.SlogAuditStore
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockLogger = testutil.NewMockLogger(ctrl)
+		store = audit.NewSlogAuditStore(mockLogger)
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("Ping", func() {
+		It("always returns nil", func() {
+			err := store.Ping(ctx)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("RecordRevocation — Scope=token", func() {
+		It("calls logger.Info with msg 'token revoked' and all key-value pairs, returns nil", func() {
+			event := audit.RevocationEvent{
+				TenantID:       "tenant-1",
+				CallerIdentity: "caller-1",
+				TokenID:        "tok-abc",
+				Target:         "",
+				Scope:          audit.RevocationScopeToken,
+				OccurredAt:     time.Now().UTC(),
+			}
+			mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
+				"tenant_id", event.TenantID,
+				"caller_identity", event.CallerIdentity,
+				"token_id", event.TokenID,
+				"target", event.Target,
+				"scope", event.Scope,
+				"occurred_at", event.OccurredAt.Format(time.RFC3339),
+			)
+			err := store.RecordRevocation(ctx, event)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("RecordRevocation — Scope=audience", func() {
+		It("emits target as audience value and token_id as empty string, returns nil", func() {
+			event := audit.RevocationEvent{
+				TenantID:       "tenant-1",
+				CallerIdentity: "caller-1",
+				TokenID:        "",
+				Target:         "api",
+				Scope:          audit.RevocationScopeAudience,
+				OccurredAt:     time.Now().UTC(),
+			}
+			mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
+				"tenant_id", event.TenantID,
+				"caller_identity", event.CallerIdentity,
+				"token_id", event.TokenID,
+				"target", event.Target,
+				"scope", event.Scope,
+				"occurred_at", event.OccurredAt.Format(time.RFC3339),
+			)
+			err := store.RecordRevocation(ctx, event)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("RecordRevocation — Scope=user", func() {
+		It("emits target as user ID value and token_id as empty string, returns nil", func() {
+			event := audit.RevocationEvent{
+				TenantID:       "tenant-1",
+				CallerIdentity: "caller-1",
+				TokenID:        "",
+				Target:         "user-1",
+				Scope:          audit.RevocationScopeUser,
+				OccurredAt:     time.Now().UTC(),
+			}
+			mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
+				"tenant_id", event.TenantID,
+				"caller_identity", event.CallerIdentity,
+				"token_id", event.TokenID,
+				"target", event.Target,
+				"scope", event.Scope,
+				"occurred_at", event.OccurredAt.Format(time.RFC3339),
+			)
+			err := store.RecordRevocation(ctx, event)
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Config", func() {
 		os.Unsetenv("TOKEN_ENGINE_REDIS_ADDR")
 		os.Unsetenv("TOKEN_ENGINE_REDIS_PASSWORD")
 		os.Unsetenv("TOKEN_ENGINE_REDIS_DB")
+		os.Unsetenv("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE")
 	}
 
 	AfterEach(func() {
@@ -134,6 +135,47 @@ var _ = Describe("Config", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.IdempotencyTTL).To(Equal(5 * time.Minute))
+
+			cleanupEnvVars()
+		})
+	})
+
+	Context("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE set to valid duration", func() {
+		It("parses and stores the duration", func() {
+			setRequiredEnvVars()
+			os.Setenv("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE", "10m")
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.JWKSCacheMaxAge).To(Equal(10 * time.Minute))
+
+			cleanupEnvVars()
+		})
+	})
+
+	Context("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE absent", func() {
+		It("uses default of 5m", func() {
+			setRequiredEnvVars()
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.JWKSCacheMaxAge).To(Equal(5 * time.Minute))
+
+			cleanupEnvVars()
+		})
+	})
+
+	Context("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE set to unparseable value", func() {
+		It("logs warning and uses default of 5m", func() {
+			setRequiredEnvVars()
+			os.Setenv("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE", "notaduration")
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.JWKSCacheMaxAge).To(Equal(5 * time.Minute))
 
 			cleanupEnvVars()
 		})

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"time"
 
 	tokenv1 "github.com/aetomala/token-engine/gen/v1"
 	"github.com/aetomala/token-engine/internal/audit"
+	"github.com/aetomala/token-engine/internal/config"
 	"github.com/aetomala/token-engine/internal/handler"
 	obs "github.com/aetomala/token-engine/internal/observability"
 	"github.com/aetomala/token-engine/internal/testutil"
@@ -428,6 +432,601 @@ var _ = Describe("Phase 4: TokenHandler — observability", func() {
 				TenantId:     "test-tenant",
 			})
 			Expect(err).NotTo(BeNil())
+		})
+	})
+})
+
+// ===== Phase 3: RevokeToken =====
+
+var _ = Describe("Phase 3: TokenHandler — RevokeToken", func() {
+	var (
+		ctx            context.Context
+		cancel         context.CancelFunc
+		ctrl           *gomock.Controller
+		mockReg        *testutil.MockTenantRegistry
+		mockAuditStore *testutil.MockStore
+		mockTM         *testutil.MockTokenManager
+		h              *handler.TokenHandler
+		req            *tokenv1.RevokeTokenRequest
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockAuditStore = testutil.NewMockStore(ctrl)
+		mockTM = testutil.NewMockTokenManager(ctrl)
+		h = handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+		req = &tokenv1.RevokeTokenRequest{TenantId: "tenant-1", RefreshToken: "raw-token"}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when audit store Ping fails", func() {
+		It("returns codes.Unavailable without calling the Manager", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			resp, err := h.RevokeToken(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeToken(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+
+	Context("when IntrospectToken fails", func() {
+		It("maps the error via MapLibraryError", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(nil, errors.New("introspect failed"))
+			resp, err := h.RevokeToken(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("does not call RevokeRefreshToken", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(nil, errors.New("introspect failed"))
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeToken(ctx, req)
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(nil, errors.New("introspect failed"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeToken(ctx, req)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("when RevokeRefreshToken succeeds", func() {
+		It("calls RecordRevocation with Scope=token and TokenID from IntrospectToken", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Cond(func(v interface{}) bool {
+				e, ok := v.(audit.RevocationEvent)
+				return ok && e.Scope == audit.RevocationScopeToken && e.TokenID == "tok-123"
+			})).Return(nil)
+			resp, err := h.RevokeToken(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("returns empty RevokeTokenResponse and nil error", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+			resp, err := h.RevokeToken(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(&tokenv1.RevokeTokenResponse{}))
+		})
+	})
+
+	Context("when RevokeRefreshToken fails", func() {
+		It("maps the error via MapLibraryError", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(storage.ErrTokenNotFound)
+			resp, err := h.RevokeToken(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(storage.ErrTokenNotFound)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeToken(ctx, req)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("when RecordRevocation fails after successful revocation", func() {
+		It("returns codes.Internal", func() {
+			mockLogger := testutil.NewMockLogger(ctrl)
+			hWithLogger := handler.NewTokenHandler(mockReg, mockAuditStore, mockLogger, obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(errors.New("db write failed"))
+			mockLogger.EXPECT().Error(gomock.Any(), "failed to record revocation audit", "error", gomock.Any())
+			resp, err := hWithLogger.RevokeToken(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+			Expect(resp).To(BeNil())
+		})
+
+		It("logs ERROR", func() {
+			mockLogger := testutil.NewMockLogger(ctrl)
+			hWithLogger := handler.NewTokenHandler(mockReg, mockAuditStore, mockLogger, obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(errors.New("db write failed"))
+			mockLogger.EXPECT().Error(gomock.Any(), "failed to record revocation audit", "error", gomock.Any())
+			_, _ = hWithLogger.RevokeToken(ctx, req)
+			// gomock verifies mockLogger.Error was called via ctrl.Finish() in AfterEach
+			Expect(true).To(BeTrue())
+		})
+	})
+
+	Context("observability", func() {
+		It("opens and ends a span named 'RevokeToken'", func() {
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+			hObs := handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+			mockTracer.EXPECT().Start(gomock.Any(), "RevokeToken").Return(ctx, mockSpan)
+			mockSpan.EXPECT().SetStatus(obs.StatusOK, "")
+			mockSpan.EXPECT().End()
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().IntrospectToken(gomock.Any(), req.RefreshToken).Return(&tokens.TokenMetadata{TokenID: "tok-123"}, nil)
+			mockTM.EXPECT().RevokeRefreshToken(gomock.Any(), "tok-123").Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+			_, err := hObs.RevokeToken(ctx, req)
+			Expect(err).To(BeNil())
+		})
+
+		It("records error on span when handler returns non-nil error", func() {
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+			hObs := handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+			mockTracer.EXPECT().Start(gomock.Any(), "RevokeToken").Return(ctx, mockSpan)
+			mockSpan.EXPECT().RecordError(gomock.Any())
+			mockSpan.EXPECT().SetStatus(obs.StatusError, gomock.Any())
+			mockSpan.EXPECT().End()
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("unavailable"))
+			_, err := hObs.RevokeToken(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+})
+
+// ===== Phase 3: RevokeAllForAudience =====
+
+var _ = Describe("Phase 3: TokenHandler — RevokeAllForAudience", func() {
+	var (
+		ctx            context.Context
+		cancel         context.CancelFunc
+		ctrl           *gomock.Controller
+		mockReg        *testutil.MockTenantRegistry
+		mockAuditStore *testutil.MockStore
+		mockTM         *testutil.MockTokenManager
+		h              *handler.TokenHandler
+		req            *tokenv1.RevokeAudienceRequest
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockAuditStore = testutil.NewMockStore(ctrl)
+		mockTM = testutil.NewMockTokenManager(ctrl)
+		h = handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+		req = &tokenv1.RevokeAudienceRequest{TenantId: "tenant-1", Audience: "api"}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when audit store Ping fails", func() {
+		It("returns codes.Unavailable without calling the Manager", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			resp, err := h.RevokeAllForAudience(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeAllForAudience(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+
+	Context("when RevokeAllForAudience succeeds", func() {
+		It("calls RecordRevocation with Scope=audience and Target=req.Audience", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForAudience(gomock.Any(), req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Cond(func(v interface{}) bool {
+				e, ok := v.(audit.RevocationEvent)
+				return ok && e.Scope == audit.RevocationScopeAudience && e.Target == req.Audience
+			})).Return(nil)
+			resp, err := h.RevokeAllForAudience(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("returns empty RevokeTokenResponse and nil error", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForAudience(gomock.Any(), req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+			resp, err := h.RevokeAllForAudience(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(&tokenv1.RevokeTokenResponse{}))
+		})
+	})
+
+	Context("when RevokeAllForAudience fails", func() {
+		It("maps the error via MapLibraryError", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForAudience(gomock.Any(), req.Audience).Return(errors.New("revoke failed"))
+			resp, err := h.RevokeAllForAudience(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForAudience(gomock.Any(), req.Audience).Return(errors.New("revoke failed"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeAllForAudience(ctx, req)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("when RecordRevocation fails after successful revocation", func() {
+		It("returns codes.Internal", func() {
+			mockLogger := testutil.NewMockLogger(ctrl)
+			hWithLogger := handler.NewTokenHandler(mockReg, mockAuditStore, mockLogger, obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForAudience(gomock.Any(), req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(errors.New("db write failed"))
+			mockLogger.EXPECT().Error(gomock.Any(), "failed to record revocation audit", "error", gomock.Any())
+			resp, err := hWithLogger.RevokeAllForAudience(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+			Expect(resp).To(BeNil())
+		})
+	})
+
+	Context("observability", func() {
+		It("opens and ends a span named 'RevokeAllForAudience'", func() {
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+			hObs := handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+			mockTracer.EXPECT().Start(gomock.Any(), "RevokeAllForAudience").Return(ctx, mockSpan)
+			mockSpan.EXPECT().SetStatus(obs.StatusOK, "")
+			mockSpan.EXPECT().End()
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForAudience(gomock.Any(), req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+			_, err := hObs.RevokeAllForAudience(ctx, req)
+			Expect(err).To(BeNil())
+		})
+
+		It("records error on span when handler returns non-nil error", func() {
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+			hObs := handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+			mockTracer.EXPECT().Start(gomock.Any(), "RevokeAllForAudience").Return(ctx, mockSpan)
+			mockSpan.EXPECT().RecordError(gomock.Any())
+			mockSpan.EXPECT().SetStatus(obs.StatusError, gomock.Any())
+			mockSpan.EXPECT().End()
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("unavailable"))
+			_, err := hObs.RevokeAllForAudience(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+})
+
+// ===== Phase 3: RevokeAllUserTokens =====
+
+var _ = Describe("Phase 3: TokenHandler — RevokeAllUserTokens", func() {
+	var (
+		ctx            context.Context
+		cancel         context.CancelFunc
+		ctrl           *gomock.Controller
+		mockReg        *testutil.MockTenantRegistry
+		mockAuditStore *testutil.MockStore
+		mockTM         *testutil.MockTokenManager
+		h              *handler.TokenHandler
+		req            *tokenv1.RevokeUserRequest
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockAuditStore = testutil.NewMockStore(ctrl)
+		mockTM = testutil.NewMockTokenManager(ctrl)
+		h = handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+		req = &tokenv1.RevokeUserRequest{TenantId: "tenant-1", UserId: "user-1"}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when audit store Ping fails", func() {
+		It("returns codes.Unavailable without calling the Manager", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			resp, err := h.RevokeAllUserTokens(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeAllUserTokens(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+
+	Context("when RevokeAllUserTokens succeeds", func() {
+		It("calls RecordRevocation with Scope=user and Target=req.UserId", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllUserTokens(gomock.Any(), req.UserId).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Cond(func(v interface{}) bool {
+				e, ok := v.(audit.RevocationEvent)
+				return ok && e.Scope == audit.RevocationScopeUser && e.Target == req.UserId
+			})).Return(nil)
+			resp, err := h.RevokeAllUserTokens(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).NotTo(BeNil())
+		})
+
+		It("returns empty RevokeTokenResponse and nil error", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllUserTokens(gomock.Any(), req.UserId).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+			resp, err := h.RevokeAllUserTokens(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(&tokenv1.RevokeTokenResponse{}))
+		})
+	})
+
+	Context("when RevokeAllUserTokens fails", func() {
+		It("maps the error via MapLibraryError", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllUserTokens(gomock.Any(), req.UserId).Return(errors.New("revoke failed"))
+			resp, err := h.RevokeAllUserTokens(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+
+		It("does not call RecordRevocation", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllUserTokens(gomock.Any(), req.UserId).Return(errors.New("revoke failed"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+			_, err := h.RevokeAllUserTokens(ctx, req)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("when RecordRevocation fails after successful revocation", func() {
+		It("returns codes.Internal", func() {
+			mockLogger := testutil.NewMockLogger(ctrl)
+			hWithLogger := handler.NewTokenHandler(mockReg, mockAuditStore, mockLogger, obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllUserTokens(gomock.Any(), req.UserId).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(errors.New("db write failed"))
+			mockLogger.EXPECT().Error(gomock.Any(), "failed to record revocation audit", "error", gomock.Any())
+			resp, err := hWithLogger.RevokeAllUserTokens(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+			Expect(resp).To(BeNil())
+		})
+	})
+
+	Context("observability", func() {
+		It("opens and ends a span named 'RevokeAllUserTokens'", func() {
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+			hObs := handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+			mockTracer.EXPECT().Start(gomock.Any(), "RevokeAllUserTokens").Return(ctx, mockSpan)
+			mockSpan.EXPECT().SetStatus(obs.StatusOK, "")
+			mockSpan.EXPECT().End()
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllUserTokens(gomock.Any(), req.UserId).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+			_, err := hObs.RevokeAllUserTokens(ctx, req)
+			Expect(err).To(BeNil())
+		})
+
+		It("records error on span when handler returns non-nil error", func() {
+			mockTracer := testutil.NewMockTracer(ctrl)
+			mockSpan := testutil.NewMockSpan(ctrl)
+			hObs := handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), mockTracer, obs.NewNoOpMetrics())
+			mockTracer.EXPECT().Start(gomock.Any(), "RevokeAllUserTokens").Return(ctx, mockSpan)
+			mockSpan.EXPECT().RecordError(gomock.Any())
+			mockSpan.EXPECT().SetStatus(obs.StatusError, gomock.Any())
+			mockSpan.EXPECT().End()
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("unavailable"))
+			_, err := hObs.RevokeAllUserTokens(ctx, req)
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+})
+
+// ===== Phase 3: JWKSHandler =====
+
+var _ = Describe("Phase 3: JWKSHandler", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		ctrl   *gomock.Controller
+		mockKM *testutil.MockKeyManager
+		testCfg *config.Config
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockKM = testutil.NewMockKeyManager(ctrl)
+		testCfg = &config.Config{JWKSCacheMaxAge: 5 * time.Minute}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when km.GetJWKS returns an error", func() {
+		It("returns 503", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(nil, errors.New("manager not running"))
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Code).To(Equal(http.StatusServiceUnavailable))
+		})
+
+		It("writes Content-Type: application/json", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(nil, errors.New("manager not running"))
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+		})
+
+		It(`writes body {"error":"key manager unavailable"}`, func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(nil, errors.New("manager not running"))
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Body.String()).To(ContainSubstring("key manager unavailable"))
+		})
+
+		It("does not write Cache-Control header", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(nil, errors.New("manager not running"))
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Header().Get("Cache-Control")).To(BeEmpty())
+		})
+	})
+
+	Context("when GetJWKS succeeds but key set is empty", func() {
+		It("returns 503", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Code).To(Equal(http.StatusServiceUnavailable))
+		})
+
+		It("writes Content-Type: application/json", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+		})
+
+		It(`writes body {"error":"no signing keys available"}`, func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Body.String()).To(ContainSubstring("no signing keys available"))
+		})
+
+		It("does not write Cache-Control header", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Header().Get("Cache-Control")).To(BeEmpty())
+		})
+	})
+
+	Context("when GetJWKS succeeds with at least one key", func() {
+		It("returns 200", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{{}}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+		})
+
+		It("writes Content-Type: application/json", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{{}}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Header().Get("Content-Type")).To(Equal("application/json"))
+		})
+
+		It("writes Cache-Control: public, max-age=N derived from cfg.JWKSCacheMaxAge", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{{}}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Header().Get("Cache-Control")).To(Equal("public, max-age=300"))
+		})
+
+		It("writes JSON-encoded JWKS body", func() {
+			mockKM.EXPECT().GetJWKS(gomock.Any()).Return(&keys.JWKS{Keys: []keys.JWK{{}}}, nil)
+			handlerFn := handler.JWKSHandler(mockKM, testCfg)
+			req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil).WithContext(ctx)
+			w := httptest.NewRecorder()
+			handlerFn(w, req)
+			Expect(w.Body.String()).NotTo(BeEmpty())
 		})
 	})
 })

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,10 +1,12 @@
 package health_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"github.com/aetomala/token-engine/internal/health"
 	"github.com/aetomala/token-engine/internal/testutil"
@@ -145,6 +147,52 @@ var _ = Describe("ReadyHandler", func() {
 			sut.ServeHTTP(w, req)
 
 			Expect(w.Code).To(Equal(http.StatusOK))
+		})
+	})
+})
+
+var _ = Describe("AuditChecker", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		ctrl   *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("Name()", func() {
+		It("returns 'audit'", func() {
+			mockStore := testutil.NewMockStore(ctrl)
+			checker := health.NewAuditChecker(mockStore)
+			Expect(checker.Name()).To(Equal(health.CheckerNameAudit))
+		})
+	})
+
+	Context("when audit.Store.Ping returns nil", func() {
+		It("returns nil", func() {
+			mockStore := testutil.NewMockStore(ctrl)
+			mockStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			checker := health.NewAuditChecker(mockStore)
+			err := checker.Check(ctx)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when audit.Store.Ping returns an error", func() {
+		It("returns a non-nil error", func() {
+			mockStore := testutil.NewMockStore(ctrl)
+			mockStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store down"))
+			checker := health.NewAuditChecker(mockStore)
+			err := checker.Check(ctx)
+			Expect(err).NotTo(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- **PHASE-10A** — `internal/audit`: SlogAuditStore tests covering interface compliance, Ping, and RecordRevocation for all three scope constants (token/audience/user). Coverage: 100%.
- **PHASE-10B** — `internal/health`: AuditChecker tests (Name, Ping success, Ping failure). Coverage: 100%. `internal/config`: JWKSCacheMaxAge tests for valid duration, absent default (5m), and unparseable fallback. Coverage: 90.3%.
- **PHASE-10C** — `internal/handler`: Full revocation handler suites (RevokeToken, RevokeAllForAudience, RevokeAllUserTokens) covering audit gate, library error mapping, RecordRevocation assertions, codes.Internal on audit failure, and observability spans. JWKSHandler tests covering all three response paths (error, empty key set, success). Coverage: 92.6%.
- All `internal/...` suites green with `-race` flag.

## Test plan

- [ ] CI passes: go vet, golangci-lint, govulncheck, go build, buf lint, ginkgo tests
- [ ] Coverage floors met: audit ≥80%, health ≥90%, config ≥85%, handler ≥80%