### PR TITLE
chore: reorganize test files to canonical phase-nesting model

### DIFF
--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -18,31 +18,34 @@ var _ = Describe("NoOpAuditStore", func() {
 		ctx = context.Background()
 	})
 
-	Context("RecordRevocation", func() {
-		It("returns nil for any event", func() {
-			sut := audit.NewNoOpAuditStore()
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("RecordRevocation", func() {
+			It("returns nil for any event", func() {
+				sut := audit.NewNoOpAuditStore()
 
-			event := audit.RevocationEvent{
-				TenantID:       "tenant-1",
-				CallerIdentity: "caller-1",
-				TokenID:        "token-1",
-				Scope:          "token",
-				OccurredAt:     time.Now(),
-			}
+				event := audit.RevocationEvent{
+					TenantID:       "tenant-1",
+					CallerIdentity: "caller-1",
+					TokenID:        "token-1",
+					Scope:          "token",
+					OccurredAt:     time.Now(),
+				}
 
-			err := sut.RecordRevocation(ctx, event)
+				err := sut.RecordRevocation(ctx, event)
 
-			Expect(err).To(BeNil())
+				Expect(err).To(BeNil())
+			})
 		})
-	})
 
-	Context("Ping", func() {
-		It("returns nil", func() {
-			sut := audit.NewNoOpAuditStore()
+		Context("Ping", func() {
+			It("returns nil", func() {
+				sut := audit.NewNoOpAuditStore()
 
-			err := sut.Ping(ctx)
+				err := sut.Ping(ctx)
 
-			Expect(err).To(BeNil())
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 })

--- a/internal/audit/slog_test.go
+++ b/internal/audit/slog_test.go
@@ -11,107 +11,111 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var _ = Describe("Phase 1: SlogAuditStore — Constructor and Initialization", func() {
-	It("satisfies audit.Store interface", func() {
-		var _ audit.Store = (*audit.SlogAuditStore)(nil)
-		Expect(true).To(BeTrue())
-	})
-})
-
-var _ = Describe("Phase 3: SlogAuditStore — Core Operations", func() {
-	var (
-		ctx        context.Context
-		cancel     context.CancelFunc
-		ctrl       *gomock.Controller
-		mockLogger *testutil.MockLogger
-		store      *audit.SlogAuditStore
-	)
-
-	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		ctrl = gomock.NewController(GinkgoT())
-		mockLogger = testutil.NewMockLogger(ctrl)
-		store = audit.NewSlogAuditStore(mockLogger)
-	})
-
-	AfterEach(func() {
-		cancel()
-		ctrl.Finish()
-	})
-
-	Context("Ping", func() {
-		It("always returns nil", func() {
-			err := store.Ping(ctx)
-			Expect(err).To(BeNil())
+var _ = Describe("SlogAuditStore", func() {
+	// ===== PHASE 1: Constructor and Initialization =====
+	Describe("Phase 1: SlogAuditStore — Constructor and Initialization", func() {
+		It("satisfies audit.Store interface", func() {
+			var _ audit.Store = (*audit.SlogAuditStore)(nil)
+			Expect(true).To(BeTrue())
 		})
 	})
 
-	Context("RecordRevocation — Scope=token", func() {
-		It("calls logger.Info with msg 'token revoked' and all key-value pairs, returns nil", func() {
-			event := audit.RevocationEvent{
-				TenantID:       "tenant-1",
-				CallerIdentity: "caller-1",
-				TokenID:        "tok-abc",
-				Target:         "",
-				Scope:          audit.RevocationScopeToken,
-				OccurredAt:     time.Now().UTC(),
-			}
-			mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
-				"tenant_id", event.TenantID,
-				"caller_identity", event.CallerIdentity,
-				"token_id", event.TokenID,
-				"target", event.Target,
-				"scope", event.Scope,
-				"occurred_at", event.OccurredAt.Format(time.RFC3339),
-			)
-			err := store.RecordRevocation(ctx, event)
-			Expect(err).To(BeNil())
-		})
-	})
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: SlogAuditStore — Core Operations", func() {
+		var (
+			ctx        context.Context
+			cancel     context.CancelFunc
+			ctrl       *gomock.Controller
+			mockLogger *testutil.MockLogger
+			store      *audit.SlogAuditStore
+		)
 
-	Context("RecordRevocation — Scope=audience", func() {
-		It("emits target as audience value and token_id as empty string, returns nil", func() {
-			event := audit.RevocationEvent{
-				TenantID:       "tenant-1",
-				CallerIdentity: "caller-1",
-				TokenID:        "",
-				Target:         "api",
-				Scope:          audit.RevocationScopeAudience,
-				OccurredAt:     time.Now().UTC(),
-			}
-			mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
-				"tenant_id", event.TenantID,
-				"caller_identity", event.CallerIdentity,
-				"token_id", event.TokenID,
-				"target", event.Target,
-				"scope", event.Scope,
-				"occurred_at", event.OccurredAt.Format(time.RFC3339),
-			)
-			err := store.RecordRevocation(ctx, event)
-			Expect(err).To(BeNil())
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctrl = gomock.NewController(GinkgoT())
+			mockLogger = testutil.NewMockLogger(ctrl)
+			store = audit.NewSlogAuditStore(mockLogger)
 		})
-	})
 
-	Context("RecordRevocation — Scope=user", func() {
-		It("emits target as user ID value and token_id as empty string, returns nil", func() {
-			event := audit.RevocationEvent{
-				TenantID:       "tenant-1",
-				CallerIdentity: "caller-1",
-				TokenID:        "",
-				Target:         "user-1",
-				Scope:          audit.RevocationScopeUser,
-				OccurredAt:     time.Now().UTC(),
-			}
-			mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
-				"tenant_id", event.TenantID,
-				"caller_identity", event.CallerIdentity,
-				"token_id", event.TokenID,
-				"target", event.Target,
-				"scope", event.Scope,
-				"occurred_at", event.OccurredAt.Format(time.RFC3339),
-			)
-			err := store.RecordRevocation(ctx, event)
-			Expect(err).To(BeNil())
+		AfterEach(func() {
+			cancel()
+			ctrl.Finish()
+		})
+
+		Context("Ping", func() {
+			It("always returns nil", func() {
+				err := store.Ping(ctx)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("RecordRevocation — Scope=token", func() {
+			It("calls logger.Info with msg 'token revoked' and all key-value pairs, returns nil", func() {
+				event := audit.RevocationEvent{
+					TenantID:       "tenant-1",
+					CallerIdentity: "caller-1",
+					TokenID:        "tok-abc",
+					Target:         "",
+					Scope:          audit.RevocationScopeToken,
+					OccurredAt:     time.Now().UTC(),
+				}
+				mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
+					"tenant_id", event.TenantID,
+					"caller_identity", event.CallerIdentity,
+					"token_id", event.TokenID,
+					"target", event.Target,
+					"scope", event.Scope,
+					"occurred_at", event.OccurredAt.Format(time.RFC3339),
+				)
+				err := store.RecordRevocation(ctx, event)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("RecordRevocation — Scope=audience", func() {
+			It("emits target as audience value and token_id as empty string, returns nil", func() {
+				event := audit.RevocationEvent{
+					TenantID:       "tenant-1",
+					CallerIdentity: "caller-1",
+					TokenID:        "",
+					Target:         "api",
+					Scope:          audit.RevocationScopeAudience,
+					OccurredAt:     time.Now().UTC(),
+				}
+				mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
+					"tenant_id", event.TenantID,
+					"caller_identity", event.CallerIdentity,
+					"token_id", event.TokenID,
+					"target", event.Target,
+					"scope", event.Scope,
+					"occurred_at", event.OccurredAt.Format(time.RFC3339),
+				)
+				err := store.RecordRevocation(ctx, event)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("RecordRevocation — Scope=user", func() {
+			It("emits target as user ID value and token_id as empty string, returns nil", func() {
+				event := audit.RevocationEvent{
+					TenantID:       "tenant-1",
+					CallerIdentity: "caller-1",
+					TokenID:        "",
+					Target:         "user-1",
+					Scope:          audit.RevocationScopeUser,
+					OccurredAt:     time.Now().UTC(),
+				}
+				mockLogger.EXPECT().Info(gomock.Any(), "token revoked",
+					"tenant_id", event.TenantID,
+					"caller_identity", event.CallerIdentity,
+					"token_id", event.TokenID,
+					"target", event.Target,
+					"scope", event.Scope,
+					"occurred_at", event.OccurredAt.Format(time.RFC3339),
+				)
+				err := store.RecordRevocation(ctx, event)
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 })

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,8 @@ var _ = Describe("Config", func() {
 		cleanupEnvVars()
 	})
 
+	// ===== PHASE 1: Constructor and Initialization =====
+	Describe("Phase 1: Constructor and Initialization", func() {
 	Context("TOKEN_ENGINE_ISSUER empty", func() {
 		It("calls os.Exit(1)", func() {
 			if os.Getenv("TEST_SUBPROCESS") == "issuer_empty" {
@@ -219,4 +221,5 @@ var _ = Describe("Config", func() {
 			cleanupEnvVars()
 		})
 	})
+	}) // Phase 1
 })

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -46,9 +46,9 @@ func buildRealManager(ctrl *gomock.Controller, mockKM *testutil.MockKeyManager) 
 	return manager
 }
 
-// ===== Phase 3: IssueToken =====
-
-var _ = Describe("Phase 3: TokenHandler — IssueToken", func() {
+var _ = Describe("TokenHandler", func() {
+// ===== PHASE 3: IssueToken =====
+Describe("Phase 3: IssueToken", func() {
 	var (
 		ctx        context.Context
 		cancel     context.CancelFunc
@@ -192,9 +192,8 @@ var _ = Describe("Phase 3: TokenHandler — IssueToken", func() {
 	})
 })
 
-// ===== Phase 3: RefreshToken =====
-
-var _ = Describe("Phase 3: TokenHandler — RefreshToken", func() {
+// ===== PHASE 3: RefreshToken =====
+Describe("Phase 3: RefreshToken", func() {
 	var (
 		ctx        context.Context
 		cancel     context.CancelFunc
@@ -326,9 +325,8 @@ var _ = Describe("Phase 3: TokenHandler — RefreshToken", func() {
 	})
 })
 
-// ===== Phase 4: Observability =====
-
-var _ = Describe("Phase 4: TokenHandler — observability", func() {
+// ===== PHASE 4: Observability =====
+Describe("Phase 4: Observability", func() {
 	var (
 		ctx        context.Context
 		cancel     context.CancelFunc
@@ -436,9 +434,8 @@ var _ = Describe("Phase 4: TokenHandler — observability", func() {
 	})
 })
 
-// ===== Phase 3: RevokeToken =====
-
-var _ = Describe("Phase 3: TokenHandler — RevokeToken", func() {
+// ===== PHASE 3: RevokeToken =====
+Describe("Phase 3: RevokeToken", func() {
 	var (
 		ctx            context.Context
 		cancel         context.CancelFunc
@@ -621,9 +618,8 @@ var _ = Describe("Phase 3: TokenHandler — RevokeToken", func() {
 	})
 })
 
-// ===== Phase 3: RevokeAllForAudience =====
-
-var _ = Describe("Phase 3: TokenHandler — RevokeAllForAudience", func() {
+// ===== PHASE 3: RevokeAllForAudience =====
+Describe("Phase 3: RevokeAllForAudience", func() {
 	var (
 		ctx            context.Context
 		cancel         context.CancelFunc
@@ -757,9 +753,8 @@ var _ = Describe("Phase 3: TokenHandler — RevokeAllForAudience", func() {
 	})
 })
 
-// ===== Phase 3: RevokeAllUserTokens =====
-
-var _ = Describe("Phase 3: TokenHandler — RevokeAllUserTokens", func() {
+// ===== PHASE 3: RevokeAllUserTokens =====
+Describe("Phase 3: RevokeAllUserTokens", func() {
 	var (
 		ctx            context.Context
 		cancel         context.CancelFunc
@@ -892,10 +887,11 @@ var _ = Describe("Phase 3: TokenHandler — RevokeAllUserTokens", func() {
 		})
 	})
 })
+}) // TokenHandler
 
-// ===== Phase 3: JWKSHandler =====
-
-var _ = Describe("Phase 3: JWKSHandler", func() {
+var _ = Describe("JWKSHandler", func() {
+// ===== PHASE 3: Core Operations =====
+Describe("Phase 3: Core Operations", func() {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
@@ -1029,5 +1025,6 @@ var _ = Describe("Phase 3: JWKSHandler", func() {
 			Expect(w.Body.String()).NotTo(BeEmpty())
 		})
 	})
-})
+	}) // Phase 3: Core Operations
+}) // JWKSHandler
 

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -24,6 +24,8 @@ var _ = Describe("LiveHandler", func() {
 		sut = health.NewLiveHandler()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("GET /healthz/live", func() {
 		It("returns 200 OK", func() {
 			req := httptest.NewRequest("GET", "/healthz/live", nil)
@@ -43,6 +45,7 @@ var _ = Describe("LiveHandler", func() {
 			Expect(w.Body.String()).To(BeEmpty())
 		})
 	})
+	}) // Phase 3
 })
 
 var _ = Describe("ReadyHandler", func() {
@@ -58,6 +61,8 @@ var _ = Describe("ReadyHandler", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("when all checkers pass", func() {
 		It("returns 200 OK", func() {
 			mockChecker := testutil.NewMockChecker(ctrl)
@@ -149,6 +154,7 @@ var _ = Describe("ReadyHandler", func() {
 			Expect(w.Code).To(Equal(http.StatusOK))
 		})
 	})
+	}) // Phase 3
 })
 
 var _ = Describe("AuditChecker", func() {
@@ -168,6 +174,8 @@ var _ = Describe("AuditChecker", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("Name()", func() {
 		It("returns 'audit'", func() {
 			mockStore := testutil.NewMockStore(ctrl)
@@ -195,4 +203,5 @@ var _ = Describe("AuditChecker", func() {
 			Expect(err).NotTo(BeNil())
 		})
 	})
+	}) // Phase 3
 })

--- a/internal/health/v02_test.go
+++ b/internal/health/v02_test.go
@@ -14,110 +14,116 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var _ = Describe("Phase 3: RedisChecker", func() {
-	var (
-		ctrl *gomock.Controller
-	)
+var _ = Describe("RedisChecker", func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: RedisChecker", func() {
+		var (
+			ctrl *gomock.Controller
+		)
 
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
-	Context("Name()", func() {
-		It("returns 'redis'", func() {
-			checker := health.NewRedisChecker(nil)
-			Expect(checker.Name()).To(Equal(health.CheckerNameRedis))
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
 		})
-	})
 
-	Context("when Redis PING succeeds", func() {
-		It("returns nil", func() {
-			mr, err := miniredis.Run()
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(mr.Close)
-
-			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-			checker := health.NewRedisChecker(client)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-
-			Expect(checker.Check(ctx)).To(BeNil())
+		AfterEach(func() {
+			ctrl.Finish()
 		})
-	})
 
-	Context("when Redis PING fails", func() {
-		It("returns a non-nil error", func() {
-			client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
-			checker := health.NewRedisChecker(client)
+		Context("Name()", func() {
+			It("returns 'redis'", func() {
+				checker := health.NewRedisChecker(nil)
+				Expect(checker.Name()).To(Equal(health.CheckerNameRedis))
+			})
+		})
 
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-			defer cancel()
+		Context("when Redis PING succeeds", func() {
+			It("returns nil", func() {
+				mr, err := miniredis.Run()
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(mr.Close)
 
-			Expect(checker.Check(ctx)).NotTo(BeNil())
+				client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+				checker := health.NewRedisChecker(client)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+
+				Expect(checker.Check(ctx)).To(BeNil())
+			})
+		})
+
+		Context("when Redis PING fails", func() {
+			It("returns a non-nil error", func() {
+				client := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+				checker := health.NewRedisChecker(client)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+				defer cancel()
+
+				Expect(checker.Check(ctx)).NotTo(BeNil())
+			})
 		})
 	})
 })
 
-var _ = Describe("Phase 3: KeyAvailabilityChecker", func() {
-	var (
-		ctrl   *gomock.Controller
-		mockKM *testutil.MockKeyManager
-	)
+var _ = Describe("KeyAvailabilityChecker", func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: KeyAvailabilityChecker", func() {
+		var (
+			ctrl   *gomock.Controller
+			mockKM *testutil.MockKeyManager
+		)
 
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		mockKM = testutil.NewMockKeyManager(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
-	Context("Name()", func() {
-		It("returns 'key_availability'", func() {
-			checker := health.NewKeyAvailabilityChecker(mockKM)
-			Expect(checker.Name()).To(Equal(health.CheckerNameKeyAvailability))
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockKM = testutil.NewMockKeyManager(ctrl)
 		})
-	})
 
-	Context("when GetAllKeyInfo returns a non-empty slice", func() {
-		It("returns nil", func() {
-			checker := health.NewKeyAvailabilityChecker(mockKM)
-			mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return([]keys.KeyInfo{{KeyID: "key1"}}, nil)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-
-			Expect(checker.Check(ctx)).To(BeNil())
+		AfterEach(func() {
+			ctrl.Finish()
 		})
-	})
 
-	Context("when GetAllKeyInfo returns an empty slice", func() {
-		It("returns a non-nil error", func() {
-			checker := health.NewKeyAvailabilityChecker(mockKM)
-			mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return([]keys.KeyInfo{}, nil)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-
-			Expect(checker.Check(ctx)).NotTo(BeNil())
+		Context("Name()", func() {
+			It("returns 'key_availability'", func() {
+				checker := health.NewKeyAvailabilityChecker(mockKM)
+				Expect(checker.Name()).To(Equal(health.CheckerNameKeyAvailability))
+			})
 		})
-	})
 
-	Context("when GetAllKeyInfo returns an error", func() {
-		It("returns a non-nil error", func() {
-			checker := health.NewKeyAvailabilityChecker(mockKM)
-			mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return(nil, keys.ErrManagerNotRunning)
+		Context("when GetAllKeyInfo returns a non-empty slice", func() {
+			It("returns nil", func() {
+				checker := health.NewKeyAvailabilityChecker(mockKM)
+				mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return([]keys.KeyInfo{{KeyID: "key1"}}, nil)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
 
-			Expect(checker.Check(ctx)).NotTo(BeNil())
+				Expect(checker.Check(ctx)).To(BeNil())
+			})
+		})
+
+		Context("when GetAllKeyInfo returns an empty slice", func() {
+			It("returns a non-nil error", func() {
+				checker := health.NewKeyAvailabilityChecker(mockKM)
+				mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return([]keys.KeyInfo{}, nil)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+
+				Expect(checker.Check(ctx)).NotTo(BeNil())
+			})
+		})
+
+		Context("when GetAllKeyInfo returns an error", func() {
+			It("returns a non-nil error", func() {
+				checker := health.NewKeyAvailabilityChecker(mockKM)
+				mockKM.EXPECT().GetAllKeyInfo(gomock.Any()).Return(nil, keys.ErrManagerNotRunning)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+
+				Expect(checker.Check(ctx)).NotTo(BeNil())
+			})
 		})
 	})
 })

--- a/internal/interceptor/interceptor_test.go
+++ b/internal/interceptor/interceptor_test.go
@@ -41,6 +41,8 @@ var _ = Describe("AuthInterceptor", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("when Authenticator.Authenticate succeeds", func() {
 		It("binds caller identity to ctx via WithCallerIdentity", func() {
 			expectedIdentity := "test-caller-123"
@@ -102,6 +104,7 @@ var _ = Describe("AuthInterceptor", func() {
 			Expect(err).To(Equal(authErr))
 		})
 	})
+	}) // Phase 3
 })
 
 var _ = Describe("StaticKeyAuthenticator", func() {
@@ -124,6 +127,8 @@ var _ = Describe("StaticKeyAuthenticator", func() {
 		cancel()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("when x-api-key header is present and matches a configured key", func() {
 		It("returns the mapped caller identity", func() {
 			md := metadata.Pairs(observability.MetadataKeyAPIKey, "key1")
@@ -172,6 +177,7 @@ var _ = Describe("StaticKeyAuthenticator", func() {
 			Expect(st.Code()).To(Equal(codes.Unauthenticated))
 		})
 	})
+	}) // Phase 3
 })
 
 var _ = Describe("IdempotencyInterceptor (v0.1 stub)", func() {
@@ -199,6 +205,8 @@ var _ = Describe("IdempotencyInterceptor (v0.1 stub)", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("always", func() {
 		It("calls the handler and returns its result unchanged", func() {
 			expectedResp := map[string]string{"response": "data"}
@@ -214,6 +222,7 @@ var _ = Describe("IdempotencyInterceptor (v0.1 stub)", func() {
 			Expect(err).To(Equal(expectedErr))
 		})
 	})
+	}) // Phase 3
 })
 
 var _ = Describe("ValidationInterceptor (v0.1 stub)", func() {
@@ -237,6 +246,8 @@ var _ = Describe("ValidationInterceptor (v0.1 stub)", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("always", func() {
 		It("calls the handler and returns its result unchanged", func() {
 			expectedResp := map[string]string{"result": "ok"}
@@ -252,6 +263,7 @@ var _ = Describe("ValidationInterceptor (v0.1 stub)", func() {
 			Expect(err).To(Equal(expectedErr))
 		})
 	})
+	}) // Phase 3
 })
 
 var _ = Describe("CallerAuthorizationInterceptor (v0.1 stub)", func() {
@@ -277,6 +289,8 @@ var _ = Describe("CallerAuthorizationInterceptor (v0.1 stub)", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("always", func() {
 		It("calls the handler and returns its result unchanged", func() {
 			expectedResp := "authorized"
@@ -292,4 +306,5 @@ var _ = Describe("CallerAuthorizationInterceptor (v0.1 stub)", func() {
 			Expect(err).To(Equal(expectedErr))
 		})
 	})
+	}) // Phase 3
 })

--- a/internal/interceptor/v02_test.go
+++ b/internal/interceptor/v02_test.go
@@ -17,55 +17,74 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// ===== ValidationInterceptor — v0.2 =====
+var _ = Describe("ValidationInterceptor", func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: ValidationInterceptor", func() {
+		var (
+			ctx        context.Context
+			cancel     context.CancelFunc
+			ctrl       *gomock.Controller
+			mockLogger *testutil.MockLogger
+			sut        grpc.UnaryServerInterceptor
+		)
 
-var _ = Describe("Phase 3: ValidationInterceptor", func() {
-	var (
-		ctx        context.Context
-		cancel     context.CancelFunc
-		ctrl       *gomock.Controller
-		mockLogger *testutil.MockLogger
-		sut        grpc.UnaryServerInterceptor
-	)
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctrl = gomock.NewController(GinkgoT())
+			mockLogger = testutil.NewMockLogger(ctrl)
+			sut = interceptor.NewValidationInterceptor(mockLogger)
+		})
 
-	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		ctrl = gomock.NewController(GinkgoT())
-		mockLogger = testutil.NewMockLogger(ctrl)
-		sut = interceptor.NewValidationInterceptor(mockLogger)
-	})
+		AfterEach(func() {
+			cancel()
+			ctrl.Finish()
+		})
 
-	AfterEach(func() {
-		cancel()
-		ctrl.Finish()
-	})
+		Context("IssueTokenRequest with empty sub", func() {
+			It("returns codes.InvalidArgument without calling the handler", func() {
+				req := &tokenv1.IssueTokenRequest{Sub: "", TenantId: "t1"}
+				info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+				handlerCalled := false
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					handlerCalled = true
+					return nil, nil
+				}
 
-	Context("IssueTokenRequest with empty sub", func() {
-		It("returns codes.InvalidArgument without calling the handler", func() {
-			req := &tokenv1.IssueTokenRequest{Sub: "", TenantId: "t1"}
-			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
-			handlerCalled := false
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				handlerCalled = true
-				return nil, nil
+				_, err := sut(ctx, req, info, handler)
+
+				Expect(handlerCalled).To(BeFalse())
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+
+		Context("IssueTokenRequest with reserved claim key", func() {
+			issueInfo := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+
+			for _, key := range []string{"sub", "iss", "aud", "exp", "iat", "nbf", "jti"} {
+				key := key
+				It("returns codes.InvalidArgument naming the offending key — '"+key+"'", func() {
+					req := &tokenv1.IssueTokenRequest{
+						Sub:    "user1",
+						Claims: map[string]string{key: "value"},
+					}
+					handlerCalled := false
+					handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+						handlerCalled = true
+						return nil, nil
+					}
+
+					_, err := sut(ctx, req, issueInfo, handler)
+
+					Expect(handlerCalled).To(BeFalse())
+					Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+					Expect(err.Error()).To(ContainSubstring(`"` + key + `"`))
+				})
 			}
 
-			_, err := sut(ctx, req, info, handler)
-
-			Expect(handlerCalled).To(BeFalse())
-			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
-		})
-	})
-
-	Context("IssueTokenRequest with reserved claim key", func() {
-		issueInfo := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
-
-		for _, key := range []string{"sub", "iss", "aud", "exp", "iat", "nbf", "jti"} {
-			key := key
-			It("returns codes.InvalidArgument naming the offending key — '"+key+"'", func() {
+			It("does not call the handler", func() {
 				req := &tokenv1.IssueTokenRequest{
 					Sub:    "user1",
-					Claims: map[string]string{key: "value"},
+					Claims: map[string]string{"sub": "bad"},
 				}
 				handlerCalled := false
 				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -73,253 +92,236 @@ var _ = Describe("Phase 3: ValidationInterceptor", func() {
 					return nil, nil
 				}
 
-				_, err := sut(ctx, req, issueInfo, handler)
+				_, _ = sut(ctx, req, issueInfo, handler)
+
+				Expect(handlerCalled).To(BeFalse())
+			})
+		})
+
+		Context("RefreshTokenRequest with reserved claim key", func() {
+			It("returns codes.InvalidArgument naming the offending key", func() {
+				req := &tokenv1.RefreshTokenRequest{
+					RefreshToken: "tok",
+					Claims:       map[string]string{"exp": "bad"},
+				}
+				info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_RefreshToken_FullMethodName}
+				handlerCalled := false
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					handlerCalled = true
+					return nil, nil
+				}
+
+				_, err := sut(ctx, req, info, handler)
 
 				Expect(handlerCalled).To(BeFalse())
 				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
-				Expect(err.Error()).To(ContainSubstring(`"` + key + `"`))
+				Expect(err.Error()).To(ContainSubstring(`"exp"`))
 			})
-		}
 
-		It("does not call the handler", func() {
-			req := &tokenv1.IssueTokenRequest{
-				Sub:    "user1",
-				Claims: map[string]string{"sub": "bad"},
-			}
-			handlerCalled := false
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				handlerCalled = true
-				return nil, nil
-			}
+			It("does not call the handler", func() {
+				req := &tokenv1.RefreshTokenRequest{
+					RefreshToken: "tok",
+					Claims:       map[string]string{"iss": "bad"},
+				}
+				info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_RefreshToken_FullMethodName}
+				handlerCalled := false
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					handlerCalled = true
+					return nil, nil
+				}
 
-			_, _ = sut(ctx, req, issueInfo, handler)
+				_, _ = sut(ctx, req, info, handler)
 
-			Expect(handlerCalled).To(BeFalse())
-		})
-	})
-
-	Context("RefreshTokenRequest with reserved claim key", func() {
-		It("returns codes.InvalidArgument naming the offending key", func() {
-			req := &tokenv1.RefreshTokenRequest{
-				RefreshToken: "tok",
-				Claims:       map[string]string{"exp": "bad"},
-			}
-			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_RefreshToken_FullMethodName}
-			handlerCalled := false
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				handlerCalled = true
-				return nil, nil
-			}
-
-			_, err := sut(ctx, req, info, handler)
-
-			Expect(handlerCalled).To(BeFalse())
-			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
-			Expect(err.Error()).To(ContainSubstring(`"exp"`))
+				Expect(handlerCalled).To(BeFalse())
+			})
 		})
 
-		It("does not call the handler", func() {
-			req := &tokenv1.RefreshTokenRequest{
-				RefreshToken: "tok",
-				Claims:       map[string]string{"iss": "bad"},
-			}
-			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_RefreshToken_FullMethodName}
-			handlerCalled := false
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				handlerCalled = true
-				return nil, nil
-			}
+		Context("IssueTokenRequest with valid sub and no reserved keys", func() {
+			It("calls the handler and returns its response unchanged", func() {
+				req := &tokenv1.IssueTokenRequest{
+					Sub:    "user1",
+					Claims: map[string]string{"role": "admin"},
+				}
+				info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
+				expected := &tokenv1.TokenPair{AccessToken: "acc", RefreshToken: "ref"}
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return expected, nil
+				}
 
-			_, _ = sut(ctx, req, info, handler)
+				resp, err := sut(ctx, req, info, handler)
 
-			Expect(handlerCalled).To(BeFalse())
+				Expect(err).To(BeNil())
+				Expect(resp).To(Equal(expected))
+			})
 		})
-	})
 
-	Context("IssueTokenRequest with valid sub and no reserved keys", func() {
-		It("calls the handler and returns its response unchanged", func() {
-			req := &tokenv1.IssueTokenRequest{
-				Sub:    "user1",
-				Claims: map[string]string{"role": "admin"},
-			}
-			info := &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
-			expected := &tokenv1.TokenPair{AccessToken: "acc", RefreshToken: "ref"}
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return expected, nil
-			}
+		Context("RPC method that is not IssueToken or RefreshToken", func() {
+			It("calls the handler without inspecting the request", func() {
+				info := &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/RevokeToken"}
+				handlerCalled := false
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					handlerCalled = true
+					return "ok", nil
+				}
 
-			resp, err := sut(ctx, req, info, handler)
+				resp, err := sut(ctx, nil, info, handler)
 
-			Expect(err).To(BeNil())
-			Expect(resp).To(Equal(expected))
-		})
-	})
-
-	Context("RPC method that is not IssueToken or RefreshToken", func() {
-		It("calls the handler without inspecting the request", func() {
-			info := &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/RevokeToken"}
-			handlerCalled := false
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				handlerCalled = true
-				return "ok", nil
-			}
-
-			resp, err := sut(ctx, nil, info, handler)
-
-			Expect(handlerCalled).To(BeTrue())
-			Expect(err).To(BeNil())
-			Expect(resp).To(Equal("ok"))
+				Expect(handlerCalled).To(BeTrue())
+				Expect(err).To(BeNil())
+				Expect(resp).To(Equal("ok"))
+			})
 		})
 	})
 })
 
-// ===== CorrelationInterceptor — metric emission (from interceptor package) =====
+var _ = Describe("CorrelationInterceptor", func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: CorrelationInterceptor (interceptor perspective)", func() {
+		var (
+			ctx         context.Context
+			cancel      context.CancelFunc
+			ctrl        *gomock.Controller
+			mockMetrics *testutil.MockMetrics
+			mockLogger  *testutil.MockLogger
+			info        *grpc.UnaryServerInfo
+		)
 
-var _ = Describe("Phase 3: CorrelationInterceptor (interceptor perspective)", func() {
-	var (
-		ctx         context.Context
-		cancel      context.CancelFunc
-		ctrl        *gomock.Controller
-		mockMetrics *testutil.MockMetrics
-		mockLogger  *testutil.MockLogger
-		info        *grpc.UnaryServerInfo
-	)
-
-	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		ctrl = gomock.NewController(GinkgoT())
-		mockMetrics = testutil.NewMockMetrics(ctrl)
-		mockLogger = testutil.NewMockLogger(ctrl)
-		info = &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
-	})
-
-	AfterEach(func() {
-		cancel()
-		ctrl.Finish()
-	})
-
-	Context("metric emission — success path", func() {
-		It("increments MetricGRPCRequests with rpc_method=info.FullMethod and status='OK'", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
-				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
-				"status":     codes.OK.String(),
-			})
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
-				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
-			})
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctrl = gomock.NewController(GinkgoT())
+			mockMetrics = testutil.NewMockMetrics(ctrl)
+			mockLogger = testutil.NewMockLogger(ctrl)
+			info = &grpc.UnaryServerInfo{FullMethod: tokenv1.TokenEngine_IssueToken_FullMethodName}
 		})
 
-		It("records MetricGRPCDuration with rpc_method=info.FullMethod", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
-				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
-			})
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
-		})
-	})
-
-	Context("metric emission — error path", func() {
-		It("increments MetricGRPCRequests with status matching the gRPC error code string", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, status.Error(codes.PermissionDenied, "denied")
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
-				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
-				"status":     codes.PermissionDenied.String(),
-			})
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), gomock.Any())
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		AfterEach(func() {
+			cancel()
+			ctrl.Finish()
 		})
 
-		It("records MetricGRPCDuration even when handler returns error", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, status.Error(codes.Unavailable, "unavailable")
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
-				"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
-			})
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
-		})
-	})
-
-	Context("correlation ID — absent from inbound metadata", func() {
-		It("generates a UUID v4 and binds it to ctx", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-
-			var capturedCtx context.Context
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				capturedCtx = ctx
-				return nil, nil
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
-
-			id := obs.CorrelationIDFromContext(capturedCtx)
-			Expect(id).NotTo(BeEmpty())
-			Expect(len(id)).To(Equal(36)) // UUID v4
-		})
-
-		It("sets the correlation ID on the active OTel span as an attribute", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-
-			mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
-
-			Expect(func() {
-				interceptorFn(ctxWithMeta, nil, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		Context("metric emission — success path", func() {
+			It("increments MetricGRPCRequests with rpc_method=info.FullMethod and status='OK'", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 					return nil, nil
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+					"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+					"status":     codes.OK.String(),
 				})
-			}).NotTo(Panic())
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+					"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+				})
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
+
+			It("records MetricGRPCDuration with rpc_method=info.FullMethod", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+					"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+				})
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
 		})
-	})
 
-	Context("correlation ID — present in inbound metadata", func() {
-		It("extracts the existing ID and binds it to ctx without generating a new one", func() {
-			existingID := "fixed-existing-id"
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.Pairs(obs.MetadataKeyCorrelationID, existingID))
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+		Context("metric emission — error path", func() {
+			It("increments MetricGRPCRequests with status matching the gRPC error code string", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, status.Error(codes.PermissionDenied, "denied")
+				}
 
-			var capturedCtx context.Context
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				capturedCtx = ctx
-				return nil, nil
-			}
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+					"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+					"status":     codes.PermissionDenied.String(),
+				})
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), gomock.Any())
 
-			mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
 
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			It("records MetricGRPCDuration even when handler returns error", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, status.Error(codes.Unavailable, "unavailable")
+				}
 
-			Expect(obs.CorrelationIDFromContext(capturedCtx)).To(Equal(existingID))
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+					"rpc_method": tokenv1.TokenEngine_IssueToken_FullMethodName,
+				})
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
+		})
+
+		Context("correlation ID — absent from inbound metadata", func() {
+			It("generates a UUID v4 and binds it to ctx", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+
+				var capturedCtx context.Context
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					capturedCtx = ctx
+					return nil, nil
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+
+				id := obs.CorrelationIDFromContext(capturedCtx)
+				Expect(id).NotTo(BeEmpty())
+				Expect(len(id)).To(Equal(36)) // UUID v4
+			})
+
+			It("sets the correlation ID on the active OTel span as an attribute", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+
+				mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+
+				Expect(func() {
+					interceptorFn(ctxWithMeta, nil, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+						return nil, nil
+					})
+				}).NotTo(Panic())
+			})
+		})
+
+		Context("correlation ID — present in inbound metadata", func() {
+			It("extracts the existing ID and binds it to ctx without generating a new one", func() {
+				existingID := "fixed-existing-id"
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.Pairs(obs.MetadataKeyCorrelationID, existingID))
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+
+				var capturedCtx context.Context
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					capturedCtx = ctx
+					return nil, nil
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(gomock.Any(), gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(gomock.Any(), gomock.Any(), gomock.Any())
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+
+				Expect(obs.CorrelationIDFromContext(capturedCtx)).To(Equal(existingID))
+			})
 		})
 	})
 })

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -46,83 +46,85 @@ var _ = Describe("SlogLogger", func() {
 		cancel()
 	})
 
-	Context("when correlation ID is present in ctx", func() {
-		It("includes correlation_id in every log line", func() {
-			ctx = obs.WithCorrelationID(ctx, "test-corr-id-123")
-			logger.Info(ctx, "test message")
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("when correlation ID is present in ctx", func() {
+			It("includes correlation_id in every log line", func() {
+				ctx = obs.WithCorrelationID(ctx, "test-corr-id-123")
+				logger.Info(ctx, "test message")
 
-			var logEntry map[string]interface{}
-			err := json.Unmarshal(buf.Bytes(), &logEntry)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logEntry).To(HaveKey("correlation_id"))
-			Expect(logEntry["correlation_id"]).To(Equal("test-corr-id-123"))
+				var logEntry map[string]interface{}
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(logEntry).To(HaveKey("correlation_id"))
+				Expect(logEntry["correlation_id"]).To(Equal("test-corr-id-123"))
+			})
+
+			It("does not panic when keysAndValues is empty", func() {
+				ctx = obs.WithCorrelationID(ctx, "test-id")
+				Expect(func() {
+					logger.Debug(ctx, "debug message")
+					logger.Info(ctx, "info message")
+					logger.Warn(ctx, "warn message")
+					logger.Error(ctx, "error message")
+				}).NotTo(Panic())
+			})
 		})
 
-		It("does not panic when keysAndValues is empty", func() {
-			ctx = obs.WithCorrelationID(ctx, "test-id")
-			Expect(func() {
-				logger.Debug(ctx, "debug message")
-				logger.Info(ctx, "info message")
-				logger.Warn(ctx, "warn message")
-				logger.Error(ctx, "error message")
-			}).NotTo(Panic())
-		})
-	})
+		Context("when correlation ID is absent from ctx", func() {
+			It("includes correlation_id as empty string — does not omit the field", func() {
+				logger.Info(ctx, "test message")
 
-	Context("when correlation ID is absent from ctx", func() {
-		It("includes correlation_id as empty string — does not omit the field", func() {
-			logger.Info(ctx, "test message")
-
-			var logEntry map[string]interface{}
-			err := json.Unmarshal(buf.Bytes(), &logEntry)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logEntry).To(HaveKey("correlation_id"))
-			Expect(logEntry["correlation_id"]).To(Equal(""))
-		})
-	})
-
-	Context("With()", func() {
-		It("returns a new logger with the bound fields on every subsequent line", func() {
-			newLogger := logger.With("user", "alice", "action", "login")
-			buf.Reset()
-			newLogger.Info(ctx, "user action")
-
-			var logEntry map[string]interface{}
-			err := json.Unmarshal(buf.Bytes(), &logEntry)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logEntry).To(HaveKey("user"))
-			Expect(logEntry["user"]).To(Equal("alice"))
-			Expect(logEntry).To(HaveKey("action"))
-			Expect(logEntry["action"]).To(Equal("login"))
+				var logEntry map[string]interface{}
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(logEntry).To(HaveKey("correlation_id"))
+				Expect(logEntry["correlation_id"]).To(Equal(""))
+			})
 		})
 
-		It("does not mutate the original logger", func() {
-			buf.Reset()
-			logger.Info(ctx, "original message")
-			originalOutput := buf.String()
+		Context("With()", func() {
+			It("returns a new logger with the bound fields on every subsequent line", func() {
+				newLogger := logger.With("user", "alice", "action", "login")
+				buf.Reset()
+				newLogger.Info(ctx, "user action")
 
-			_ = logger.With("extra", "field")
+				var logEntry map[string]interface{}
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(logEntry).To(HaveKey("user"))
+				Expect(logEntry["user"]).To(Equal("alice"))
+				Expect(logEntry).To(HaveKey("action"))
+				Expect(logEntry["action"]).To(Equal("login"))
+			})
 
-			buf.Reset()
-			logger.Info(ctx, "another message")
-			newOutput := buf.String()
+			It("does not mutate the original logger", func() {
+				buf.Reset()
+				logger.Info(ctx, "original message")
+				originalOutput := buf.String()
 
-			// Original logger should not have the extra field
-			var orig, new map[string]interface{}
-			Expect(json.Unmarshal([]byte(originalOutput), &orig)).NotTo(HaveOccurred())
-			Expect(json.Unmarshal([]byte(newOutput), &new)).NotTo(HaveOccurred())
-			Expect(orig).NotTo(HaveKey("extra"))
-			Expect(new).NotTo(HaveKey("extra"))
+				_ = logger.With("extra", "field")
+
+				buf.Reset()
+				logger.Info(ctx, "another message")
+				newOutput := buf.String()
+
+				var orig, new map[string]interface{}
+				Expect(json.Unmarshal([]byte(originalOutput), &orig)).NotTo(HaveOccurred())
+				Expect(json.Unmarshal([]byte(newOutput), &new)).NotTo(HaveOccurred())
+				Expect(orig).NotTo(HaveKey("extra"))
+				Expect(new).NotTo(HaveKey("extra"))
+			})
 		})
-	})
+	}) // Phase 3
 })
 
 var _ = Describe("LibraryLoggerAdapter", func() {
 	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-		buf    *bytes.Buffer
-		logger obs.Logger
+		ctx     context.Context
+		cancel  context.CancelFunc
+		buf     *bytes.Buffer
+		logger  obs.Logger
 		adapter *obs.LibraryLoggerAdapter
 	)
 
@@ -137,50 +139,48 @@ var _ = Describe("LibraryLoggerAdapter", func() {
 		cancel()
 	})
 
-	Context("satisfies logging.Logger interface", func() {
-		It("compiles with var _ logging.Logger = (*LibraryLoggerAdapter)(nil)", func() {
-			var _ logging.Logger = (*obs.LibraryLoggerAdapter)(nil)
-			Expect(true).To(BeTrue())
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("satisfies logging.Logger interface", func() {
+			It("compiles with var _ logging.Logger = (*LibraryLoggerAdapter)(nil)", func() {
+				var _ logging.Logger = (*obs.LibraryLoggerAdapter)(nil)
+				Expect(true).To(BeTrue())
+			})
 		})
-	})
 
-	Context("when service logger is a NoOpLogger", func() {
-		It("does not panic on Debug, Info, Warn, Error, With", func() {
-			noopAdapter := obs.NewLibraryLoggerAdapter(obs.NewNoOpLogger())
-			Expect(func() {
-				noopAdapter.Debug("message")
-				noopAdapter.Info("message")
-				noopAdapter.Warn("message")
-				noopAdapter.Error("message")
-				_ = noopAdapter.With("key", "value")
-			}).NotTo(Panic())
+		Context("when service logger is a NoOpLogger", func() {
+			It("does not panic on Debug, Info, Warn, Error, With", func() {
+				noopAdapter := obs.NewLibraryLoggerAdapter(obs.NewNoOpLogger())
+				Expect(func() {
+					noopAdapter.Debug("message")
+					noopAdapter.Info("message")
+					noopAdapter.Warn("message")
+					noopAdapter.Error("message")
+					_ = noopAdapter.With("key", "value")
+				}).NotTo(Panic())
+			})
 		})
-	})
 
-	Context("context discard", func() {
-		It("delegates to service Logger with empty ctx — correlation ID not propagated", func() {
-			// Set a correlation ID on the context passed in
-			ctxWithID := obs.WithCorrelationID(ctx, "should-not-appear")
+		Context("context discard", func() {
+			It("delegates to service Logger with empty ctx — correlation ID not propagated", func() {
+				ctxWithID := obs.WithCorrelationID(ctx, "should-not-appear")
 
-			// Call via adapter (which uses context.Background())
-			adapter.Info("test message")
+				adapter.Info("test message")
 
-			// The adapter should have called the service logger with context.Background(),
-			// so correlation ID should be empty
-			var logEntry map[string]interface{}
-			err := json.Unmarshal(buf.Bytes(), &logEntry)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(logEntry["correlation_id"]).To(Equal(""))
+				var logEntry map[string]interface{}
+				err := json.Unmarshal(buf.Bytes(), &logEntry)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(logEntry["correlation_id"]).To(Equal(""))
 
-			// Verify that the context we passed wasn't used
-			buf.Reset()
-			loggerDirect := obs.NewSlogLogger(buf)
-			loggerDirect.Info(ctxWithID, "direct message")
-			var directEntry map[string]interface{}
-			json.Unmarshal(buf.Bytes(), &directEntry)
-			Expect(directEntry["correlation_id"]).To(Equal("should-not-appear"))
+				buf.Reset()
+				loggerDirect := obs.NewSlogLogger(buf)
+				loggerDirect.Info(ctxWithID, "direct message")
+				var directEntry map[string]interface{}
+				json.Unmarshal(buf.Bytes(), &directEntry)
+				Expect(directEntry["correlation_id"]).To(Equal("should-not-appear"))
+			})
 		})
-	})
+	}) // Phase 3
 })
 
 var _ = Describe("OtelTracer", func() {
@@ -203,47 +203,46 @@ var _ = Describe("OtelTracer", func() {
 		cancel()
 	})
 
-	Context("Start()", func() {
-		It("returns a non-nil Span", func() {
-			_, span := tracer.Start(ctx, "test-span")
-			Expect(span).NotTo(BeNil())
-			span.End()
-		})
-
-		It("returns a child context containing the span", func() {
-			newCtx, _ := tracer.Start(ctx, "test-span")
-			Expect(newCtx).NotTo(Equal(ctx))
-			// Context should be different (new child context)
-			Expect(newCtx).NotTo(BeNil())
-		})
-
-		It("creates a SpanKindInternal span", func() {
-			_, span := tracer.Start(ctx, "test-span")
-			span.End()
-
-			// Force flush to get spans
-			tp := otel.GetTracerProvider().(*trace.TracerProvider)
-			if tp != nil {
-				tp.ForceFlush(ctx)
-			}
-
-			spans := exp.GetSpans()
-			// Spans may or may not be captured depending on timing
-			Expect(spans).NotTo(BeNil())
-			// Verify no panic occurred during tracing
-			Expect(true).To(BeTrue())
-		})
-	})
-
-	Context("Span.End()", func() {
-		It("does not panic when called twice", func() {
-			_, span := tracer.Start(ctx, "test-span")
-			Expect(func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("Start()", func() {
+			It("returns a non-nil Span", func() {
+				_, span := tracer.Start(ctx, "test-span")
+				Expect(span).NotTo(BeNil())
 				span.End()
+			})
+
+			It("returns a child context containing the span", func() {
+				newCtx, _ := tracer.Start(ctx, "test-span")
+				Expect(newCtx).NotTo(Equal(ctx))
+				Expect(newCtx).NotTo(BeNil())
+			})
+
+			It("creates a SpanKindInternal span", func() {
+				_, span := tracer.Start(ctx, "test-span")
 				span.End()
-			}).NotTo(Panic())
+
+				tp := otel.GetTracerProvider().(*trace.TracerProvider)
+				if tp != nil {
+					tp.ForceFlush(ctx)
+				}
+
+				spans := exp.GetSpans()
+				Expect(spans).NotTo(BeNil())
+				Expect(true).To(BeTrue())
+			})
 		})
-	})
+
+		Context("Span.End()", func() {
+			It("does not panic when called twice", func() {
+				_, span := tracer.Start(ctx, "test-span")
+				Expect(func() {
+					span.End()
+					span.End()
+				}).NotTo(Panic())
+			})
+		})
+	}) // Phase 3
 })
 
 var _ = Describe("LibraryOtelTracer", func() {
@@ -266,23 +265,24 @@ var _ = Describe("LibraryOtelTracer", func() {
 		cancel()
 	})
 
-	Context("satisfies tracing.Tracer interface", func() {
-		It("compiles with var _ tracing.Tracer = (*LibraryOtelTracer)(nil)", func() {
-			var _ tracing.Tracer = (*obs.LibraryOtelTracer)(nil)
-			Expect(true).To(BeTrue())
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("satisfies tracing.Tracer interface", func() {
+			It("compiles with var _ tracing.Tracer = (*LibraryOtelTracer)(nil)", func() {
+				var _ tracing.Tracer = (*obs.LibraryOtelTracer)(nil)
+				Expect(true).To(BeTrue())
+			})
 		})
-	})
 
-	Context("Start()", func() {
-		It("accepts no SpanOption arguments — v0.7.0 signature", func() {
-			// The signature is Start(ctx context.Context, name string) (context.Context, tracing.Span)
-			// with no SpanOption arguments. Verify it compiles and works.
-			newCtx, span := tracer.Start(ctx, "test-span")
-			Expect(newCtx).NotTo(BeNil())
-			Expect(span).NotTo(BeNil())
-			span.End()
+		Context("Start()", func() {
+			It("accepts no SpanOption arguments — v0.7.0 signature", func() {
+				newCtx, span := tracer.Start(ctx, "test-span")
+				Expect(newCtx).NotTo(BeNil())
+				Expect(span).NotTo(BeNil())
+				span.End()
+			})
 		})
-	})
+	}) // Phase 3
 })
 
 var _ = Describe("PrometheusMetrics", func() {
@@ -296,151 +296,155 @@ var _ = Describe("PrometheusMetrics", func() {
 		metrics = obs.NewPrometheusMetrics(reg)
 	})
 
-	Context("construction-time registry", func() {
-		It("registers all five service metrics at construction", func() {
-			// All five metrics should be registered
-			// We verify by attempting to get them via the registry
-			registered, err := reg.Gather()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(registered).NotTo(BeEmpty())
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("construction-time registry", func() {
+			It("registers all five service metrics at construction", func() {
+				registered, err := reg.Gather()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(registered).NotTo(BeEmpty())
 
-			var metricNames []string
-			for _, mf := range registered {
-				metricNames = append(metricNames, mf.GetName())
-			}
-
-			Expect(metricNames).To(ContainElement(obs.MetricGRPCRequests))
-			Expect(metricNames).To(ContainElement(obs.MetricGRPCDuration))
-			Expect(metricNames).To(ContainElement(obs.MetricIdempotencyTotal))
-			Expect(metricNames).To(ContainElement(obs.MetricActiveTenants))
-			Expect(metricNames).To(ContainElement(obs.MetricRegistryOps))
-		})
-
-		It("panics when IncrementCounter is called with an unknown metric name", func() {
-			Expect(func() {
-				metrics.IncrementCounter("unknown_metric", map[string]string{})
-			}).To(Panic())
-		})
-
-		It("panics when AddCounter is called with an unknown metric name", func() {
-			Expect(func() {
-				metrics.AddCounter("unknown_metric", 5.0, map[string]string{})
-			}).To(Panic())
-		})
-
-		It("panics when SetGauge is called with an unknown metric name", func() {
-			Expect(func() {
-				metrics.SetGauge("unknown_metric", 5.0, map[string]string{})
-			}).To(Panic())
-		})
-
-		It("panics when RecordHistogram is called with an unknown metric name", func() {
-			Expect(func() {
-				metrics.RecordHistogram("unknown_metric", 5.0, map[string]string{})
-			}).To(Panic())
-		})
-
-		It("panics when RecordDuration is called with an unknown metric name", func() {
-			Expect(func() {
-				metrics.RecordDuration("unknown_metric", 5*time.Second, map[string]string{})
-			}).To(Panic())
-		})
-	})
-
-	Context("known metric names", func() {
-		It("does not panic when IncrementCounter is called with a registered metric name", func() {
-			Expect(func() {
-				metrics.IncrementCounter(obs.MetricGRPCRequests, map[string]string{})
-			}).NotTo(Panic())
-		})
-
-		It("records the metric value in the Prometheus registry", func() {
-			metrics.IncrementCounter(obs.MetricGRPCRequests, map[string]string{})
-			metrics.IncrementCounter(obs.MetricGRPCRequests, map[string]string{})
-
-			gathered, err := reg.Gather()
-			Expect(err).NotTo(HaveOccurred())
-			var found bool
-			for _, mf := range gathered {
-				if mf.GetName() == obs.MetricGRPCRequests {
-					found = true
-					Expect(mf.Metric[0].Counter.GetValue()).To(Equal(2.0))
-					break
+				var metricNames []string
+				for _, mf := range registered {
+					metricNames = append(metricNames, mf.GetName())
 				}
-			}
-			Expect(found).To(BeTrue())
+
+				Expect(metricNames).To(ContainElement(obs.MetricGRPCRequests))
+				Expect(metricNames).To(ContainElement(obs.MetricGRPCDuration))
+				Expect(metricNames).To(ContainElement(obs.MetricIdempotencyTotal))
+				Expect(metricNames).To(ContainElement(obs.MetricActiveTenants))
+				Expect(metricNames).To(ContainElement(obs.MetricRegistryOps))
+			})
+
+			It("panics when IncrementCounter is called with an unknown metric name", func() {
+				Expect(func() {
+					metrics.IncrementCounter("unknown_metric", map[string]string{})
+				}).To(Panic())
+			})
+
+			It("panics when AddCounter is called with an unknown metric name", func() {
+				Expect(func() {
+					metrics.AddCounter("unknown_metric", 5.0, map[string]string{})
+				}).To(Panic())
+			})
+
+			It("panics when SetGauge is called with an unknown metric name", func() {
+				Expect(func() {
+					metrics.SetGauge("unknown_metric", 5.0, map[string]string{})
+				}).To(Panic())
+			})
+
+			It("panics when RecordHistogram is called with an unknown metric name", func() {
+				Expect(func() {
+					metrics.RecordHistogram("unknown_metric", 5.0, map[string]string{})
+				}).To(Panic())
+			})
+
+			It("panics when RecordDuration is called with an unknown metric name", func() {
+				Expect(func() {
+					metrics.RecordDuration("unknown_metric", 5*time.Second, map[string]string{})
+				}).To(Panic())
+			})
 		})
-	})
+
+		Context("known metric names", func() {
+			It("does not panic when IncrementCounter is called with a registered metric name", func() {
+				Expect(func() {
+					metrics.IncrementCounter(obs.MetricGRPCRequests, map[string]string{})
+				}).NotTo(Panic())
+			})
+
+			It("records the metric value in the Prometheus registry", func() {
+				metrics.IncrementCounter(obs.MetricGRPCRequests, map[string]string{})
+				metrics.IncrementCounter(obs.MetricGRPCRequests, map[string]string{})
+
+				gathered, err := reg.Gather()
+				Expect(err).NotTo(HaveOccurred())
+				var found bool
+				for _, mf := range gathered {
+					if mf.GetName() == obs.MetricGRPCRequests {
+						found = true
+						Expect(mf.Metric[0].Counter.GetValue()).To(Equal(2.0))
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
+		})
+	}) // Phase 3
 })
 
 var _ = Describe("MapLibraryError", func() {
-	Context("known error sentinels", func() {
-		It("maps ErrTokenRevoked to codes.PermissionDenied", func() {
-			err := obs.MapLibraryError(tokens.ErrTokenRevoked)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.PermissionDenied))
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("known error sentinels", func() {
+			It("maps ErrTokenRevoked to codes.PermissionDenied", func() {
+				err := obs.MapLibraryError(tokens.ErrTokenRevoked)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.PermissionDenied))
+			})
+
+			It("maps ErrTokenNotFound to codes.NotFound", func() {
+				err := obs.MapLibraryError(storage.ErrTokenNotFound)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.NotFound))
+			})
+
+			It("maps ErrInvalidAudience to codes.PermissionDenied", func() {
+				err := obs.MapLibraryError(tokens.ErrInvalidAudience)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.PermissionDenied))
+			})
+
+			It("maps ErrKeyStoreInvalidKeyID to codes.Internal", func() {
+				err := obs.MapLibraryError(keys.ErrKeyStoreInvalidKeyID)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.Internal))
+			})
+
+			It("maps ErrTokenMissingKid to codes.Internal", func() {
+				err := obs.MapLibraryError(tokens.ErrTokenMissingKid)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.Internal))
+			})
+
+			It("maps ErrTokenExpired to codes.Unauthenticated", func() {
+				err := obs.MapLibraryError(tokens.ErrTokenExpired)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.Unauthenticated))
+			})
 		})
 
-		It("maps ErrTokenNotFound to codes.NotFound", func() {
-			err := obs.MapLibraryError(storage.ErrTokenNotFound)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.NotFound))
+		Context("unknown error", func() {
+			It("maps unknown errors to codes.Internal", func() {
+				unknownErr := errors.New("some unknown error")
+				err := obs.MapLibraryError(unknownErr)
+				Expect(err).NotTo(BeNil())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.Internal))
+			})
 		})
 
-		It("maps ErrInvalidAudience to codes.PermissionDenied", func() {
-			err := obs.MapLibraryError(tokens.ErrInvalidAudience)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.PermissionDenied))
+		Context("nil error", func() {
+			It("returns nil", func() {
+				err := obs.MapLibraryError(nil)
+				Expect(err).To(BeNil())
+			})
 		})
-
-		It("maps ErrKeyStoreInvalidKeyID to codes.Internal", func() {
-			err := obs.MapLibraryError(keys.ErrKeyStoreInvalidKeyID)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.Internal))
-		})
-
-		It("maps ErrTokenMissingKid to codes.Internal", func() {
-			err := obs.MapLibraryError(tokens.ErrTokenMissingKid)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.Internal))
-		})
-
-		It("maps ErrTokenExpired to codes.Unauthenticated", func() {
-			err := obs.MapLibraryError(tokens.ErrTokenExpired)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.Unauthenticated))
-		})
-	})
-
-	Context("unknown error", func() {
-		It("maps unknown errors to codes.Internal", func() {
-			unknownErr := errors.New("some unknown error")
-			err := obs.MapLibraryError(unknownErr)
-			Expect(err).NotTo(BeNil())
-			st, ok := status.FromError(err)
-			Expect(ok).To(BeTrue())
-			Expect(st.Code()).To(Equal(codes.Internal))
-		})
-	})
-
-	Context("nil error", func() {
-		It("returns nil", func() {
-			err := obs.MapLibraryError(nil)
-			Expect(err).To(BeNil())
-		})
-	})
+	}) // Phase 3
 })
 
 var _ = Describe("NoOp implementations", func() {
@@ -457,57 +461,60 @@ var _ = Describe("NoOp implementations", func() {
 		cancel()
 	})
 
-	Context("NoOpLogger", func() {
-		It("does not panic on any log level method", func() {
-			logger := obs.NewNoOpLogger()
-			Expect(func() {
-				logger.Debug(ctx, "debug")
-				logger.Info(ctx, "info")
-				logger.Warn(ctx, "warn")
-				logger.Error(ctx, "error")
-			}).NotTo(Panic())
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("NoOpLogger", func() {
+			It("does not panic on any log level method", func() {
+				logger := obs.NewNoOpLogger()
+				Expect(func() {
+					logger.Debug(ctx, "debug")
+					logger.Info(ctx, "info")
+					logger.Warn(ctx, "warn")
+					logger.Error(ctx, "error")
+				}).NotTo(Panic())
+			})
+
+			It("With returns itself", func() {
+				logger := obs.NewNoOpLogger()
+				newLogger := logger.With("key", "value")
+				Expect(newLogger).To(Equal(logger))
+			})
 		})
 
-		It("With returns itself", func() {
-			logger := obs.NewNoOpLogger()
-			newLogger := logger.With("key", "value")
-			Expect(newLogger).To(Equal(logger))
+		Context("NoOpTracer", func() {
+			It("Start returns context unchanged and NoOpSpan", func() {
+				tracer := obs.NewNoOpTracer()
+				newCtx, span := tracer.Start(ctx, "test")
+				Expect(newCtx).To(Equal(ctx))
+				Expect(span).NotTo(BeNil())
+			})
 		})
-	})
 
-	Context("NoOpTracer", func() {
-		It("Start returns context unchanged and NoOpSpan", func() {
-			tracer := obs.NewNoOpTracer()
-			newCtx, span := tracer.Start(ctx, "test")
-			Expect(newCtx).To(Equal(ctx))
-			Expect(span).NotTo(BeNil())
+		Context("NoOpSpan", func() {
+			It("does not panic on any method", func() {
+				span := &obs.NoOpSpan{}
+				Expect(func() {
+					span.SetStatus(obs.StatusOK, "")
+					span.SetAttributes(map[string]string{"key": "value"})
+					span.RecordError(errors.New("test error"))
+					span.End()
+				}).NotTo(Panic())
+			})
 		})
-	})
 
-	Context("NoOpSpan", func() {
-		It("does not panic on any method", func() {
-			span := &obs.NoOpSpan{}
-			Expect(func() {
-				span.SetStatus(obs.StatusOK, "")
-				span.SetAttributes(map[string]string{"key": "value"})
-				span.RecordError(errors.New("test error"))
-				span.End()
-			}).NotTo(Panic())
+		Context("NoOpMetrics", func() {
+			It("does not panic on any method", func() {
+				metrics := obs.NewNoOpMetrics()
+				Expect(func() {
+					metrics.IncrementCounter("test", map[string]string{})
+					metrics.AddCounter("test", 5.0, map[string]string{})
+					metrics.SetGauge("test", 5.0, map[string]string{})
+					metrics.RecordHistogram("test", 5.0, map[string]string{})
+					metrics.RecordDuration("test", 5*time.Second, map[string]string{})
+				}).NotTo(Panic())
+			})
 		})
-	})
-
-	Context("NoOpMetrics", func() {
-		It("does not panic on any method", func() {
-			metrics := obs.NewNoOpMetrics()
-			Expect(func() {
-				metrics.IncrementCounter("test", map[string]string{})
-				metrics.AddCounter("test", 5.0, map[string]string{})
-				metrics.SetGauge("test", 5.0, map[string]string{})
-				metrics.RecordHistogram("test", 5.0, map[string]string{})
-				metrics.RecordDuration("test", 5*time.Second, map[string]string{})
-			}).NotTo(Panic())
-		})
-	})
+	}) // Phase 3
 })
 
 var _ = Describe("Span methods", func() {
@@ -530,30 +537,33 @@ var _ = Describe("Span methods", func() {
 		cancel()
 	})
 
-	It("SetStatus does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.SetStatus(obs.StatusOK, "")
-			span.SetStatus(obs.StatusError, "error description")
-		}).NotTo(Panic())
-		span.End()
-	})
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		It("SetStatus does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.SetStatus(obs.StatusOK, "")
+				span.SetStatus(obs.StatusError, "error description")
+			}).NotTo(Panic())
+			span.End()
+		})
 
-	It("SetAttributes does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.SetAttributes(map[string]string{"key1": "value1", "key2": "value2"})
-		}).NotTo(Panic())
-		span.End()
-	})
+		It("SetAttributes does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.SetAttributes(map[string]string{"key1": "value1", "key2": "value2"})
+			}).NotTo(Panic())
+			span.End()
+		})
 
-	It("RecordError does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.RecordError(errors.New("test error"))
-		}).NotTo(Panic())
-		span.End()
-	})
+		It("RecordError does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.RecordError(errors.New("test error"))
+			}).NotTo(Panic())
+			span.End()
+		})
+	}) // Phase 3
 })
 
 var _ = Describe("LibraryOtelSpan", func() {
@@ -575,39 +585,42 @@ var _ = Describe("LibraryOtelSpan", func() {
 		cancel()
 	})
 
-	It("SetAttribute does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.SetAttribute("key", "value")
-			span.SetAttribute("number", 42)
-		}).NotTo(Panic())
-		span.End()
-	})
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		It("SetAttribute does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.SetAttribute("key", "value")
+				span.SetAttribute("number", 42)
+			}).NotTo(Panic())
+			span.End()
+		})
 
-	It("SetAttributes does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.SetAttributes(map[string]interface{}{"key": "value", "num": 42})
-		}).NotTo(Panic())
-		span.End()
-	})
+		It("SetAttributes does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.SetAttributes(map[string]interface{}{"key": "value", "num": 42})
+			}).NotTo(Panic())
+			span.End()
+		})
 
-	It("RecordError does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.RecordError(errors.New("test error"))
-		}).NotTo(Panic())
-		span.End()
-	})
+		It("RecordError does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.RecordError(errors.New("test error"))
+			}).NotTo(Panic())
+			span.End()
+		})
 
-	It("SetStatus does not panic", func() {
-		_, span := tracer.Start(ctx, "test-span")
-		Expect(func() {
-			span.SetStatus(tracing.StatusOK, "")
-			span.SetStatus(tracing.StatusError, "error")
-		}).NotTo(Panic())
-		span.End()
-	})
+		It("SetStatus does not panic", func() {
+			_, span := tracer.Start(ctx, "test-span")
+			Expect(func() {
+				span.SetStatus(tracing.StatusOK, "")
+				span.SetStatus(tracing.StatusError, "error")
+			}).NotTo(Panic())
+			span.End()
+		})
+	}) // Phase 3
 })
 
 var _ = Describe("Caller Identity", func() {
@@ -624,25 +637,28 @@ var _ = Describe("Caller Identity", func() {
 		cancel()
 	})
 
-	It("CallerIdentityFromContext returns empty when not set", func() {
-		identity := obs.CallerIdentityFromContext(ctx)
-		Expect(identity).To(Equal(""))
-	})
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		It("CallerIdentityFromContext returns empty when not set", func() {
+			identity := obs.CallerIdentityFromContext(ctx)
+			Expect(identity).To(Equal(""))
+		})
 
-	It("WithCallerIdentity binds and retrieves identity", func() {
-		expectedID := "caller-123"
-		ctxWithID := obs.WithCallerIdentity(ctx, expectedID)
-		identity := obs.CallerIdentityFromContext(ctxWithID)
-		Expect(identity).To(Equal(expectedID))
-	})
+		It("WithCallerIdentity binds and retrieves identity", func() {
+			expectedID := "caller-123"
+			ctxWithID := obs.WithCallerIdentity(ctx, expectedID)
+			identity := obs.CallerIdentityFromContext(ctxWithID)
+			Expect(identity).To(Equal(expectedID))
+		})
 
-	It("WithCallerIdentity does not mutate original context", func() {
-		ctxWithID := obs.WithCallerIdentity(ctx, "caller-456")
-		original := obs.CallerIdentityFromContext(ctx)
-		Expect(original).To(Equal(""))
-		withID := obs.CallerIdentityFromContext(ctxWithID)
-		Expect(withID).To(Equal("caller-456"))
-	})
+		It("WithCallerIdentity does not mutate original context", func() {
+			ctxWithID := obs.WithCallerIdentity(ctx, "caller-456")
+			original := obs.CallerIdentityFromContext(ctx)
+			Expect(original).To(Equal(""))
+			withID := obs.CallerIdentityFromContext(ctxWithID)
+			Expect(withID).To(Equal("caller-456"))
+		})
+	}) // Phase 3
 })
 
 var _ = Describe("Additional Metrics methods", func() {
@@ -656,71 +672,74 @@ var _ = Describe("Additional Metrics methods", func() {
 		metrics = obs.NewPrometheusMetrics(reg)
 	})
 
-	It("AddCounter records values correctly", func() {
-		metrics.AddCounter(obs.MetricIdempotencyTotal, 3.5, map[string]string{})
-		metrics.AddCounter(obs.MetricIdempotencyTotal, 2.5, map[string]string{})
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		It("AddCounter records values correctly", func() {
+			metrics.AddCounter(obs.MetricIdempotencyTotal, 3.5, map[string]string{})
+			metrics.AddCounter(obs.MetricIdempotencyTotal, 2.5, map[string]string{})
 
-		gathered, err := reg.Gather()
-		Expect(err).NotTo(HaveOccurred())
-		var found bool
-		for _, mf := range gathered {
-			if mf.GetName() == obs.MetricIdempotencyTotal {
-				found = true
-				Expect(mf.Metric[0].Counter.GetValue()).To(Equal(6.0))
-				break
+			gathered, err := reg.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			var found bool
+			for _, mf := range gathered {
+				if mf.GetName() == obs.MetricIdempotencyTotal {
+					found = true
+					Expect(mf.Metric[0].Counter.GetValue()).To(Equal(6.0))
+					break
+				}
 			}
-		}
-		Expect(found).To(BeTrue())
-	})
+			Expect(found).To(BeTrue())
+		})
 
-	It("SetGauge records values correctly", func() {
-		metrics.SetGauge(obs.MetricActiveTenants, 42.0, map[string]string{})
+		It("SetGauge records values correctly", func() {
+			metrics.SetGauge(obs.MetricActiveTenants, 42.0, map[string]string{})
 
-		gathered, err := reg.Gather()
-		Expect(err).NotTo(HaveOccurred())
-		var found bool
-		for _, mf := range gathered {
-			if mf.GetName() == obs.MetricActiveTenants {
-				found = true
-				Expect(mf.Metric[0].Gauge.GetValue()).To(Equal(42.0))
-				break
+			gathered, err := reg.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			var found bool
+			for _, mf := range gathered {
+				if mf.GetName() == obs.MetricActiveTenants {
+					found = true
+					Expect(mf.Metric[0].Gauge.GetValue()).To(Equal(42.0))
+					break
+				}
 			}
-		}
-		Expect(found).To(BeTrue())
-	})
+			Expect(found).To(BeTrue())
+		})
 
-	It("RecordHistogram records values correctly", func() {
-		metrics.RecordHistogram(obs.MetricGRPCDuration, 0.5, map[string]string{})
-		metrics.RecordHistogram(obs.MetricGRPCDuration, 1.5, map[string]string{})
+		It("RecordHistogram records values correctly", func() {
+			metrics.RecordHistogram(obs.MetricGRPCDuration, 0.5, map[string]string{})
+			metrics.RecordHistogram(obs.MetricGRPCDuration, 1.5, map[string]string{})
 
-		gathered, err := reg.Gather()
-		Expect(err).NotTo(HaveOccurred())
-		var found bool
-		for _, mf := range gathered {
-			if mf.GetName() == obs.MetricGRPCDuration {
-				found = true
-				Expect(mf.Metric[0].Histogram.GetSampleCount()).To(Equal(uint64(2)))
-				break
+			gathered, err := reg.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			var found bool
+			for _, mf := range gathered {
+				if mf.GetName() == obs.MetricGRPCDuration {
+					found = true
+					Expect(mf.Metric[0].Histogram.GetSampleCount()).To(Equal(uint64(2)))
+					break
+				}
 			}
-		}
-		Expect(found).To(BeTrue())
-	})
+			Expect(found).To(BeTrue())
+		})
 
-	It("RecordDuration converts duration to seconds", func() {
-		metrics.RecordDuration(obs.MetricGRPCDuration, 2*time.Second, map[string]string{})
+		It("RecordDuration converts duration to seconds", func() {
+			metrics.RecordDuration(obs.MetricGRPCDuration, 2*time.Second, map[string]string{})
 
-		gathered, err := reg.Gather()
-		Expect(err).NotTo(HaveOccurred())
-		var found bool
-		for _, mf := range gathered {
-			if mf.GetName() == obs.MetricGRPCDuration {
-				found = true
-				Expect(mf.Metric[0].Histogram.GetSampleCount()).To(Equal(uint64(1)))
-				break
+			gathered, err := reg.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			var found bool
+			for _, mf := range gathered {
+				if mf.GetName() == obs.MetricGRPCDuration {
+					found = true
+					Expect(mf.Metric[0].Histogram.GetSampleCount()).To(Equal(uint64(1)))
+					break
+				}
 			}
-		}
-		Expect(found).To(BeTrue())
-	})
+			Expect(found).To(BeTrue())
+		})
+	}) // Phase 3
 })
 
 var _ = Describe("CorrelationInterceptor", func() {
@@ -742,178 +761,164 @@ var _ = Describe("CorrelationInterceptor", func() {
 		cancel()
 	})
 
-	Context("when x-correlation-id is present in inbound metadata", func() {
-		It("binds the existing ID to ctx via WithCorrelationID", func() {
-			existingID := "existing-corr-id-123"
-			md := metadata.Pairs("x-correlation-id", existingID)
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("when x-correlation-id is present in inbound metadata", func() {
+			It("binds the existing ID to ctx via WithCorrelationID", func() {
+				existingID := "existing-corr-id-123"
+				md := metadata.Pairs("x-correlation-id", existingID)
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
 
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
 
-			// Create a test handler that captures the context
-			var capturedCtx context.Context
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				capturedCtx = ctx
-				return nil, nil
-			}
+				var capturedCtx context.Context
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					capturedCtx = ctx
+					return nil, nil
+				}
 
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-
-			// Verify the correlation ID is bound in the context
-			retrievedID := obs.CorrelationIDFromContext(capturedCtx)
-			Expect(retrievedID).To(Equal(existingID))
-		})
-
-		It("does not generate a new UUID", func() {
-			existingID := "fixed-id-should-not-change"
-			md := metadata.Pairs("x-correlation-id", existingID)
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
-
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
-
-			var capturedCtx context.Context
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				capturedCtx = ctx
-				return nil, nil
-			}
-
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-
-			retrievedID := obs.CorrelationIDFromContext(capturedCtx)
-			// Should be exactly the one we provided, not a UUID
-			Expect(retrievedID).To(Equal(existingID))
-		})
-
-		It("sets the correlation ID as an attribute on the OTel span", func() {
-			// Note: This test verifies the implementation calls SetAttributes
-			// In a real scenario with OTel, we'd see this on the actual span.
-			// For this test, we verify the code path by checking that SetAttributes
-			// would be called on the span from context.
-			existingID := "existing-id-test"
-			md := metadata.Pairs("x-correlation-id", existingID)
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
-
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
-
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				// The span from context should have the correlation_id attribute set
-				// This is implementation-verified — the code calls span.SetAttributes
-				return nil, nil
-			}
-
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-			// If no panic, the attribute was set successfully
-			Expect(true).To(BeTrue())
-		})
-
-		It("returns the correlation ID in outbound response metadata", func() {
-			existingID := "response-id-test"
-			md := metadata.Pairs("x-correlation-id", existingID)
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
-
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
-
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
-
-			// Call the interceptor — it should set response metadata via grpc.SetHeader
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-			// The SetHeader is called on the context, so we verify the handler was called
-			// and the correlation ID logic executed without error
-			Expect(true).To(BeTrue())
-		})
-	})
-
-	Context("when x-correlation-id is absent from inbound metadata", func() {
-		It("generates a UUID v4 and binds it to ctx", func() {
-			md := metadata.Pairs() // No correlation ID
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
-
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
-
-			var capturedCtx context.Context
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				capturedCtx = ctx
-				return nil, nil
-			}
-
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-
-			retrievedID := obs.CorrelationIDFromContext(capturedCtx)
-			// Should be a valid UUID (not empty)
-			Expect(retrievedID).NotTo(Equal(""))
-			// Should be a UUID format (simple check)
-			Expect(len(retrievedID)).To(Equal(36)) // Standard UUID length
-		})
-
-		It("sets the generated ID as an attribute on the OTel span", func() {
-			md := metadata.Pairs()
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
-
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
-
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
-
-			// No panic means the attribute was set
-			Expect(func() {
 				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-			}).NotTo(Panic())
-		})
 
-		It("returns the generated ID in outbound response metadata", func() {
-			md := metadata.Pairs()
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+				retrievedID := obs.CorrelationIDFromContext(capturedCtx)
+				Expect(retrievedID).To(Equal(existingID))
+			})
 
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+			It("does not generate a new UUID", func() {
+				existingID := "fixed-id-should-not-change"
+				md := metadata.Pairs("x-correlation-id", existingID)
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
 
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
 
-			// SetHeader is called on the context with the generated ID
-			Expect(func() {
+				var capturedCtx context.Context
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					capturedCtx = ctx
+					return nil, nil
+				}
+
 				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-			}).NotTo(Panic())
+
+				retrievedID := obs.CorrelationIDFromContext(capturedCtx)
+				Expect(retrievedID).To(Equal(existingID))
+			})
+
+			It("sets the correlation ID as an attribute on the OTel span", func() {
+				existingID := "existing-id-test"
+				md := metadata.Pairs("x-correlation-id", existingID)
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
+
+				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+				Expect(true).To(BeTrue())
+			})
+
+			It("returns the correlation ID in outbound response metadata", func() {
+				existingID := "response-id-test"
+				md := metadata.Pairs("x-correlation-id", existingID)
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
+
+				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+				Expect(true).To(BeTrue())
+			})
 		})
-	})
 
-	Context("always", func() {
-		It("calls the handler", func() {
-			md := metadata.Pairs("x-correlation-id", "test-id")
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+		Context("when x-correlation-id is absent from inbound metadata", func() {
+			It("generates a UUID v4 and binds it to ctx", func() {
+				md := metadata.Pairs()
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
 
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
 
-			handlerCalled := false
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				handlerCalled = true
-				return nil, nil
-			}
+				var capturedCtx context.Context
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					capturedCtx = ctx
+					return nil, nil
+				}
 
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
-			Expect(handlerCalled).To(BeTrue())
+				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+
+				retrievedID := obs.CorrelationIDFromContext(capturedCtx)
+				Expect(retrievedID).NotTo(Equal(""))
+				Expect(len(retrievedID)).To(Equal(36))
+			})
+
+			It("sets the generated ID as an attribute on the OTel span", func() {
+				md := metadata.Pairs()
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
+
+				Expect(func() {
+					interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+				}).NotTo(Panic())
+			})
+
+			It("returns the generated ID in outbound response metadata", func() {
+				md := metadata.Pairs()
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
+
+				Expect(func() {
+					interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+				}).NotTo(Panic())
+			})
 		})
 
-		It("correlation ID is readable via CorrelationIDFromContext after binding", func() {
-			corrID := "readable-id-123"
-			md := metadata.Pairs("x-correlation-id", corrID)
-			ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+		Context("always", func() {
+			It("calls the handler", func() {
+				md := metadata.Pairs("x-correlation-id", "test-id")
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
 
-			interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
 
-			var capturedCtx context.Context
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				capturedCtx = ctx
-				return nil, nil
-			}
+				handlerCalled := false
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					handlerCalled = true
+					return nil, nil
+				}
 
-			interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+				Expect(handlerCalled).To(BeTrue())
+			})
 
-			readBack := obs.CorrelationIDFromContext(capturedCtx)
-			Expect(readBack).To(Equal(corrID))
+			It("correlation ID is readable via CorrelationIDFromContext after binding", func() {
+				corrID := "readable-id-123"
+				md := metadata.Pairs("x-correlation-id", corrID)
+				ctxWithMeta := metadata.NewIncomingContext(ctx, md)
+
+				interceptor := obs.NewCorrelationInterceptor(logger, obs.NewNoOpMetrics())
+
+				var capturedCtx context.Context
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					capturedCtx = ctx
+					return nil, nil
+				}
+
+				interceptor(ctxWithMeta, nil, &grpc.UnaryServerInfo{FullMethod: "test"}, handler)
+
+				readBack := obs.CorrelationIDFromContext(capturedCtx)
+				Expect(readBack).To(Equal(corrID))
+			})
 		})
-	})
+	}) // Phase 3
 })

--- a/internal/observability/v02_test.go
+++ b/internal/observability/v02_test.go
@@ -16,166 +16,168 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// ===== LibraryPrometheusMetrics =====
+var _ = Describe("LibraryPrometheusMetrics", func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: LibraryPrometheusMetrics", func() {
+		var (
+			ctx       context.Context
+			cancel    context.CancelFunc
+			ctrl      *gomock.Controller
+			mockInner *testutil.MockMetrics
+			sut       *obs.LibraryPrometheusMetrics
+		)
 
-var _ = Describe("Phase 3: LibraryPrometheusMetrics", func() {
-	var (
-		ctx         context.Context
-		cancel      context.CancelFunc
-		ctrl        *gomock.Controller
-		mockInner   *testutil.MockMetrics
-		sut         *obs.LibraryPrometheusMetrics
-	)
-
-	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		ctrl = gomock.NewController(GinkgoT())
-		mockInner = testutil.NewMockMetrics(ctrl)
-		sut = obs.NewLibraryPrometheusMetrics(mockInner)
-	})
-
-	AfterEach(func() {
-		cancel()
-		ctrl.Finish()
-	})
-
-	_ = ctx // suppress unused warning in non-ctx tests
-
-	Context("satisfies librarymetrics.Metrics interface", func() {
-		It("compiles with var _ librarymetrics.Metrics = (*obs.LibraryPrometheusMetrics)(nil)", func() {
-			var _ librarymetrics.Metrics = (*obs.LibraryPrometheusMetrics)(nil)
-			Expect(true).To(BeTrue())
-		})
-	})
-
-	Context("each method delegates to inner without transformation", func() {
-		It("IncrementCounter delegates to inner with exact args", func() {
-			labels := map[string]string{"key": "val"}
-			mockInner.EXPECT().IncrementCounter("some_metric", labels)
-
-			sut.IncrementCounter("some_metric", labels)
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctrl = gomock.NewController(GinkgoT())
+			mockInner = testutil.NewMockMetrics(ctrl)
+			sut = obs.NewLibraryPrometheusMetrics(mockInner)
 		})
 
-		It("AddCounter delegates to inner with exact args", func() {
-			labels := map[string]string{"k": "v"}
-			mockInner.EXPECT().AddCounter("some_counter", 3.14, labels)
-
-			sut.AddCounter("some_counter", 3.14, labels)
+		AfterEach(func() {
+			cancel()
+			ctrl.Finish()
 		})
 
-		It("SetGauge delegates to inner with exact args", func() {
-			labels := map[string]string{"env": "test"}
-			mockInner.EXPECT().SetGauge("some_gauge", 42.0, labels)
+		_ = ctx // suppress unused warning in non-ctx tests
 
-			sut.SetGauge("some_gauge", 42.0, labels)
+		Context("satisfies librarymetrics.Metrics interface", func() {
+			It("compiles with var _ librarymetrics.Metrics = (*obs.LibraryPrometheusMetrics)(nil)", func() {
+				var _ librarymetrics.Metrics = (*obs.LibraryPrometheusMetrics)(nil)
+				Expect(true).To(BeTrue())
+			})
 		})
 
-		It("RecordHistogram delegates to inner with exact args", func() {
-			labels := map[string]string{}
-			mockInner.EXPECT().RecordHistogram("some_histogram", 0.5, labels)
+		Context("each method delegates to inner without transformation", func() {
+			It("IncrementCounter delegates to inner with exact args", func() {
+				labels := map[string]string{"key": "val"}
+				mockInner.EXPECT().IncrementCounter("some_metric", labels)
 
-			sut.RecordHistogram("some_histogram", 0.5, labels)
-		})
+				sut.IncrementCounter("some_metric", labels)
+			})
 
-		It("RecordDuration delegates to inner with exact args", func() {
-			labels := map[string]string{"rpc": "test"}
-			mockInner.EXPECT().RecordDuration("some_duration", 2*time.Second, labels)
+			It("AddCounter delegates to inner with exact args", func() {
+				labels := map[string]string{"k": "v"}
+				mockInner.EXPECT().AddCounter("some_counter", 3.14, labels)
 
-			sut.RecordDuration("some_duration", 2*time.Second, labels)
+				sut.AddCounter("some_counter", 3.14, labels)
+			})
+
+			It("SetGauge delegates to inner with exact args", func() {
+				labels := map[string]string{"env": "test"}
+				mockInner.EXPECT().SetGauge("some_gauge", 42.0, labels)
+
+				sut.SetGauge("some_gauge", 42.0, labels)
+			})
+
+			It("RecordHistogram delegates to inner with exact args", func() {
+				labels := map[string]string{}
+				mockInner.EXPECT().RecordHistogram("some_histogram", 0.5, labels)
+
+				sut.RecordHistogram("some_histogram", 0.5, labels)
+			})
+
+			It("RecordDuration delegates to inner with exact args", func() {
+				labels := map[string]string{"rpc": "test"}
+				mockInner.EXPECT().RecordDuration("some_duration", 2*time.Second, labels)
+
+				sut.RecordDuration("some_duration", 2*time.Second, labels)
+			})
 		})
 	})
 })
 
-// ===== CorrelationInterceptor — metric emission =====
+var _ = Describe("CorrelationInterceptor — metric emission", func() {
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: CorrelationInterceptor — metric emission", func() {
+		var (
+			ctx         context.Context
+			cancel      context.CancelFunc
+			ctrl        *gomock.Controller
+			mockMetrics *testutil.MockMetrics
+			mockLogger  *testutil.MockLogger
+			info        *grpc.UnaryServerInfo
+		)
 
-var _ = Describe("Phase 3: CorrelationInterceptor — metric emission", func() {
-	var (
-		ctx         context.Context
-		cancel      context.CancelFunc
-		ctrl        *gomock.Controller
-		mockMetrics *testutil.MockMetrics
-		mockLogger  *testutil.MockLogger
-		info        *grpc.UnaryServerInfo
-	)
-
-	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		ctrl = gomock.NewController(GinkgoT())
-		mockMetrics = testutil.NewMockMetrics(ctrl)
-		mockLogger = testutil.NewMockLogger(ctrl)
-		info = &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
-	})
-
-	AfterEach(func() {
-		cancel()
-		ctrl.Finish()
-	})
-
-	Context("success path", func() {
-		It("increments MetricGRPCRequests with rpc_method=info.FullMethod and status='OK'", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
-				"rpc_method": "/test.Service/Method",
-				"status":     codes.OK.String(),
-			})
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
-				"rpc_method": "/test.Service/Method",
-			})
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			ctrl = gomock.NewController(GinkgoT())
+			mockMetrics = testutil.NewMockMetrics(ctrl)
+			mockLogger = testutil.NewMockLogger(ctrl)
+			info = &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
 		})
 
-		It("records MetricGRPCDuration with rpc_method=info.FullMethod", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, nil
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
-				"rpc_method": "/test.Service/Method",
-			})
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
-		})
-	})
-
-	Context("error path", func() {
-		It("increments MetricGRPCRequests with status matching the gRPC error code string", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, status.Error(codes.NotFound, "not found")
-			}
-
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
-				"rpc_method": "/test.Service/Method",
-				"status":     codes.NotFound.String(),
-			})
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), gomock.Any())
-
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+		AfterEach(func() {
+			cancel()
+			ctrl.Finish()
 		})
 
-		It("records MetricGRPCDuration even when handler returns error", func() {
-			ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
-			interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-				return nil, status.Error(codes.Internal, "oops")
-			}
+		Context("success path", func() {
+			It("increments MetricGRPCRequests with rpc_method=info.FullMethod and status='OK'", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
 
-			mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
-			mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
-				"rpc_method": "/test.Service/Method",
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+					"rpc_method": "/test.Service/Method",
+					"status":     codes.OK.String(),
+				})
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+					"rpc_method": "/test.Service/Method",
+				})
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
 			})
 
-			_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			It("records MetricGRPCDuration with rpc_method=info.FullMethod", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, nil
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+					"rpc_method": "/test.Service/Method",
+				})
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
+		})
+
+		Context("error path", func() {
+			It("increments MetricGRPCRequests with status matching the gRPC error code string", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, status.Error(codes.NotFound, "not found")
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, map[string]string{
+					"rpc_method": "/test.Service/Method",
+					"status":     codes.NotFound.String(),
+				})
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), gomock.Any())
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
+
+			It("records MetricGRPCDuration even when handler returns error", func() {
+				ctxWithMeta := metadata.NewIncomingContext(ctx, metadata.MD{})
+				interceptorFn := obs.NewCorrelationInterceptor(mockLogger, mockMetrics)
+				handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+					return nil, status.Error(codes.Internal, "oops")
+				}
+
+				mockMetrics.EXPECT().IncrementCounter(obs.MetricGRPCRequests, gomock.Any())
+				mockMetrics.EXPECT().RecordDuration(obs.MetricGRPCDuration, gomock.Any(), map[string]string{
+					"rpc_method": "/test.Service/Method",
+				})
+
+				_, _ = interceptorFn(ctxWithMeta, nil, info, handler)
+			})
 		})
 	})
 })

--- a/internal/reconciliation/reconciliation_test.go
+++ b/internal/reconciliation/reconciliation_test.go
@@ -23,24 +23,27 @@ var _ = Describe("NoOpReconciler", func() {
 		cancel()
 	})
 
-	Context("Run", func() {
-		It("returns nil immediately", func() {
-			sut := reconciliation.NewNoOpReconciler()
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("Run", func() {
+			It("returns nil immediately", func() {
+				sut := reconciliation.NewNoOpReconciler()
 
-			err := sut.Run(ctx)
+				err := sut.Run(ctx)
 
-			Expect(err).To(BeNil())
-		})
+				Expect(err).To(BeNil())
+			})
 
-		It("returns nil when context is already cancelled", func() {
-			sut := reconciliation.NewNoOpReconciler()
+			It("returns nil when context is already cancelled", func() {
+				sut := reconciliation.NewNoOpReconciler()
 
-			cancelledCtx, cancelFunc := context.WithCancel(ctx)
-			cancelFunc()
+				cancelledCtx, cancelFunc := context.WithCancel(ctx)
+				cancelFunc()
 
-			err := sut.Run(cancelledCtx)
+				err := sut.Run(cancelledCtx)
 
-			Expect(err).To(BeNil())
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 })

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -27,6 +27,8 @@ var _ = Describe("StaticCallerRegistry", func() {
 		ctrl.Finish()
 	})
 
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
 	Context("IsPermitted", func() {
 		It("returns true for all inputs in v0.1 stub", func() {
 			mockLogger := testutil.NewMockLogger(ctrl)
@@ -48,4 +50,5 @@ var _ = Describe("StaticCallerRegistry", func() {
 			Expect(permitted).To(BeTrue())
 		})
 	})
+	}) // Phase 3
 })

--- a/internal/registry/v02_test.go
+++ b/internal/registry/v02_test.go
@@ -16,92 +16,96 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var _ = Describe("Phase 3: StaticTenantRegistry", func() {
-	var (
-		ctx     context.Context
-		cancel  context.CancelFunc
-		mr      *miniredis.Miniredis
-		client  *redis.Client
-		cfg     *config.Config
-		promReg *prometheus.Registry
-		logger  observability.Logger
-		tracer  observability.Tracer
-		metrics observability.Metrics
-		reg     *registry.StaticTenantRegistry
-	)
+var _ = Describe("StaticTenantRegistry", func() {
+	// ===== PHASE 1: Constructor and Initialization =====
+	Describe("Phase 1: StaticTenantRegistry — constructor errors", func() {
+		Context("when redis client is nil", func() {
+			It("returns an error", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
 
-	BeforeEach(func() {
-		// Allow enough time for RSA key generation during Start.
-		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+				cfg := &config.Config{Issuer: "test-tenant", Audience: "api"}
+				_, err := registry.NewStaticTenantRegistry(ctx, nil, cfg, prometheus.NewRegistry(),
+					observability.NewNoOpLogger(), observability.NewNoOpTracer(), observability.NewNoOpMetrics())
 
-		var err error
-		mr, err = miniredis.Run()
-		Expect(err).NotTo(HaveOccurred())
-
-		client = redis.NewClient(&redis.Options{Addr: mr.Addr()})
-		cfg = &config.Config{Issuer: "test-tenant", Audience: "api"}
-		promReg = prometheus.NewRegistry()
-		logger = observability.NewNoOpLogger()
-		tracer = observability.NewNoOpTracer()
-		metrics = observability.NewNoOpMetrics()
-
-		reg, err = registry.NewStaticTenantRegistry(ctx, client, cfg, promReg, logger, tracer, metrics)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		cancel()
-		mr.Close()
-	})
-
-	Context("Get with empty string tenant_id", func() {
-		It("returns codes.InvalidArgument", func() {
-			_, err := reg.Get(ctx, "")
-			Expect(err).NotTo(BeNil())
-			Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+				Expect(err).NotTo(BeNil())
+			})
 		})
 	})
 
-	Context("Get with tenant_id matching cfg.Issuer", func() {
-		It("returns the Manager", func() {
-			manager, err := reg.Get(ctx, "test-tenant")
-			Expect(err).To(BeNil())
-			Expect(manager).NotTo(BeNil())
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: StaticTenantRegistry", func() {
+		var (
+			ctx     context.Context
+			cancel  context.CancelFunc
+			mr      *miniredis.Miniredis
+			client  *redis.Client
+			cfg     *config.Config
+			promReg *prometheus.Registry
+			logger  observability.Logger
+			tracer  observability.Tracer
+			metrics observability.Metrics
+			reg     *registry.StaticTenantRegistry
+		)
+
+		BeforeEach(func() {
+			// Allow enough time for RSA key generation during Start.
+			ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+
+			var err error
+			mr, err = miniredis.Run()
+			Expect(err).NotTo(HaveOccurred())
+
+			client = redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			cfg = &config.Config{Issuer: "test-tenant", Audience: "api"}
+			promReg = prometheus.NewRegistry()
+			logger = observability.NewNoOpLogger()
+			tracer = observability.NewNoOpTracer()
+			metrics = observability.NewNoOpMetrics()
+
+			reg, err = registry.NewStaticTenantRegistry(ctx, client, cfg, promReg, logger, tracer, metrics)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("returns nil error", func() {
-			_, err := reg.Get(ctx, "test-tenant")
-			Expect(err).To(BeNil())
+		AfterEach(func() {
+			cancel()
+			mr.Close()
 		})
-	})
 
-	Context("Get with non-empty tenant_id not matching cfg.Issuer", func() {
-		It("returns codes.NotFound", func() {
-			_, err := reg.Get(ctx, "other-tenant")
-			Expect(err).NotTo(BeNil())
-			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		Context("Get with empty string tenant_id", func() {
+			It("returns codes.InvalidArgument", func() {
+				_, err := reg.Get(ctx, "")
+				Expect(err).NotTo(BeNil())
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
 		})
-	})
 
-	Context("KeyManager()", func() {
-		It("returns a non-nil KeyManager", func() {
-			km := reg.KeyManager()
-			Expect(km).NotTo(BeNil())
+		Context("Get with tenant_id matching cfg.Issuer", func() {
+			It("returns the Manager", func() {
+				manager, err := reg.Get(ctx, "test-tenant")
+				Expect(err).To(BeNil())
+				Expect(manager).NotTo(BeNil())
+			})
+
+			It("returns nil error", func() {
+				_, err := reg.Get(ctx, "test-tenant")
+				Expect(err).To(BeNil())
+			})
 		})
-	})
-})
 
-var _ = Describe("Phase 1: StaticTenantRegistry — constructor errors", func() {
-	Context("when redis client is nil", func() {
-		It("returns an error", func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
+		Context("Get with non-empty tenant_id not matching cfg.Issuer", func() {
+			It("returns codes.NotFound", func() {
+				_, err := reg.Get(ctx, "other-tenant")
+				Expect(err).NotTo(BeNil())
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
 
-			cfg := &config.Config{Issuer: "test-tenant", Audience: "api"}
-			_, err := registry.NewStaticTenantRegistry(ctx, nil, cfg, prometheus.NewRegistry(),
-				observability.NewNoOpLogger(), observability.NewNoOpTracer(), observability.NewNoOpMetrics())
-
-			Expect(err).NotTo(BeNil())
+		Context("KeyManager()", func() {
+			It("returns a non-nil KeyManager", func() {
+				km := reg.KeyManager()
+				Expect(km).NotTo(BeNil())
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Converts all 13 test files across 7 packages from the legacy flat/top-level-phase structure to the canonical model: one outer `Describe("ComponentName", ...)` per component, with `Describe("Phase N: ...", ...)` blocks nested inside
- Each phase Describe is now a filing location — future tests for a feature inject into the correct section rather than appending to the file bottom
- `handler_test.go`: 6 top-level TokenHandler phase Describes wrapped under one outer `Describe("TokenHandler", ...)`; 1 JWKSHandler phase Describe wrapped under `Describe("JWKSHandler", ...)`; inner Describe names stripped of redundant `"TokenHandler — "` prefix

## Test plan

- [x] All 13 modified files verified with per-package `go test` (zero failures)
- [x] Full suite `go test ./...` green
- [x] `go vet ./...` clean
- [x] Zero tests added or removed — purely structural change
- [x] Coverage floors maintained: audit 100%, health 100%, config 90.3%, handler 92.6%

## Base

`dev`