### PR TITLE
feat(store): implement RedisIdempotencyStore for v0.4 idempotency

### DIFF
--- a/internal/store/idempotency.go
+++ b/internal/store/idempotency.go
@@ -1,36 +1,44 @@
 package store
 
-import (
-	"context"
-	"time"
-)
+import "context"
 
-// IdempotencyStore provides caching of request responses for idempotency.
+// IdempotencyStore is the persistence layer for request deduplication.
+// Implementations must be safe for concurrent use.
+// TTL-based expiry handles cleanup — no explicit delete method.
 type IdempotencyStore interface {
-	// Get returns the cached response bytes for key, or (nil, nil) if not found.
-	Get(ctx context.Context, key string) ([]byte, error)
+	// Get retrieves a cached response for key.
+	// Returns (value, true, nil) on hit.
+	// Returns (nil, false, nil) on miss (redis.Nil maps to this).
+	// Returns (nil, false, err) on store error.
+	Get(ctx context.Context, key string) ([]byte, bool, error)
 
-	// SetNX stores value under key with the given TTL only if the key does not exist.
-	// Returns (true, nil) if the key was set. Returns (false, nil) if the key already existed.
+	// SetNX stores value at key if and only if the key does not already exist.
+	// The TTL is determined by the store implementation's construction-time config.
+	// Returns (true, nil) if the key was written.
+	// Returns (false, nil) if the key already existed — concurrent write, not an error.
 	// Returns (false, err) on store error.
-	SetNX(ctx context.Context, key string, value []byte, ttl time.Duration) (bool, error)
+	SetNX(ctx context.Context, key string, value []byte) (bool, error)
 }
 
-// NoOpIdempotencyStore is a v0.1 stub implementation of IdempotencyStore.
-// It does not cache any responses.
+// NoOpIdempotencyStore is a no-operation IdempotencyStore.
+// Get always returns a miss. SetNX always returns (true, nil).
+// Used in tests and as the pre-v0.4 stub.
 type NoOpIdempotencyStore struct{}
+
+// Compile-time interface assertion.
+var _ IdempotencyStore = (*NoOpIdempotencyStore)(nil)
 
 // NewNoOpIdempotencyStore returns a new NoOpIdempotencyStore.
 func NewNoOpIdempotencyStore() *NoOpIdempotencyStore {
 	return &NoOpIdempotencyStore{}
 }
 
-// Get returns (nil, nil) for all inputs.
-func (s *NoOpIdempotencyStore) Get(ctx context.Context, key string) ([]byte, error) {
-	return nil, nil
+// Get returns (nil, false, nil) for all inputs — always a miss.
+func (n *NoOpIdempotencyStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	return nil, false, nil
 }
 
-// SetNX returns (false, nil) for all inputs.
-func (s *NoOpIdempotencyStore) SetNX(ctx context.Context, key string, value []byte, ttl time.Duration) (bool, error) {
-	return false, nil
+// SetNX returns (true, nil) for all inputs — always signals "written successfully".
+func (n *NoOpIdempotencyStore) SetNX(ctx context.Context, key string, value []byte) (bool, error) {
+	return true, nil
 }

--- a/internal/store/redis.go
+++ b/internal/store/redis.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisIdempotencyStore is a Redis-backed IdempotencyStore.
+// TTL is fixed at construction time and applied on every SetNX call.
+// All methods are safe for concurrent use.
+type RedisIdempotencyStore struct {
+	client redis.UniversalClient
+	ttl    time.Duration
+}
+
+// Compile-time interface assertion.
+var _ IdempotencyStore = (*RedisIdempotencyStore)(nil)
+
+// NewRedisIdempotencyStore returns a new RedisIdempotencyStore using client with the given ttl.
+func NewRedisIdempotencyStore(client redis.UniversalClient, ttl time.Duration) *RedisIdempotencyStore {
+	return &RedisIdempotencyStore{client: client, ttl: ttl}
+}
+
+// Get retrieves a cached response for key.
+// Returns (value, true, nil) on hit.
+// Returns (nil, false, nil) on miss — redis.Nil is not treated as an error.
+// Returns (nil, false, err) on store error.
+func (s *RedisIdempotencyStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	val, err := s.client.Get(ctx, key).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return val, true, nil
+}
+
+// SetNX stores value at key if and only if the key does not already exist.
+// The TTL configured at construction is applied.
+// Returns (true, nil) if the key was written.
+// Returns (false, nil) if the key already existed — concurrent write, not an error.
+// Returns (false, err) on store error.
+func (s *RedisIdempotencyStore) SetNX(ctx context.Context, key string, value []byte) (bool, error) {
+	ok, err := s.client.SetNX(ctx, key, value, s.ttl).Result()
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
+}

--- a/internal/store/redis_test.go
+++ b/internal/store/redis_test.go
@@ -1,0 +1,174 @@
+package store_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/aetomala/token-engine/internal/store"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+)
+
+var _ = Describe("RedisIdempotencyStore", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		mr     *miniredis.Miniredis
+		client *redis.Client
+		sut    *store.RedisIdempotencyStore
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		var err error
+		mr, err = miniredis.Run()
+		Expect(err).NotTo(HaveOccurred())
+		client = redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		sut = store.NewRedisIdempotencyStore(client, 1*time.Minute)
+	})
+
+	AfterEach(func() {
+		cancel()
+		mr.Close()
+	})
+
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+
+		Context("when key exists in Redis", func() {
+			It("returns the stored bytes, true, and nil error", func() {
+				mr.Set("testkey", "testvalue")
+
+				val, hit, err := sut.Get(ctx, "testkey")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hit).To(BeTrue())
+				Expect(val).To(Equal([]byte("testvalue")))
+			})
+		})
+
+		Context("when key does not exist (redis.Nil)", func() {
+			It("returns nil, false, and nil error", func() {
+				val, hit, err := sut.Get(ctx, "missing-key")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hit).To(BeFalse())
+				Expect(val).To(BeNil())
+			})
+
+			It("does not treat redis.Nil as an error", func() {
+				_, _, err := sut.Get(ctx, "another-missing-key")
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when Redis returns a non-Nil error", func() {
+			It("returns nil, false, and the error", func() {
+				// Use a separate miniredis instance so closing it does not affect the shared mr
+				errorMr, err := miniredis.Run()
+				Expect(err).NotTo(HaveOccurred())
+				errorClient := redis.NewClient(&redis.Options{Addr: errorMr.Addr()})
+				errorSut := store.NewRedisIdempotencyStore(errorClient, 1*time.Minute)
+				errorMr.Close() // Close before the call to force a connection error
+
+				val, hit, getErr := errorSut.Get(ctx, "key")
+
+				Expect(val).To(BeNil())
+				Expect(hit).To(BeFalse())
+				Expect(getErr).To(HaveOccurred())
+			})
+		})
+
+		Context("when key does not exist", func() {
+			It("stores the value in Redis and returns true, nil", func() {
+				ok, err := sut.SetNX(ctx, "newkey", []byte("newvalue"))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ok).To(BeTrue())
+
+				stored, _ := mr.Get("newkey")
+				Expect(stored).To(Equal("newvalue"))
+			})
+
+			It("applies the TTL configured at construction", func() {
+				_, err := sut.SetNX(ctx, "ttlkey", []byte("v"))
+				Expect(err).NotTo(HaveOccurred())
+
+				ttl := mr.TTL("ttlkey")
+				Expect(ttl).To(BeNumerically(">", 0))
+			})
+		})
+
+		Context("when key already exists", func() {
+			It("returns false, nil and does not overwrite the existing value", func() {
+				mr.Set("existingkey", "original")
+
+				ok, err := sut.SetNX(ctx, "existingkey", []byte("overwrite"))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ok).To(BeFalse())
+
+				stored, _ := mr.Get("existingkey")
+				Expect(stored).To(Equal("original"))
+			})
+		})
+
+		Context("when Redis returns an error on SetNX", func() {
+			It("returns false and the error", func() {
+				// Use a separate miniredis instance so closing it does not affect the shared mr
+				errorMr, err := miniredis.Run()
+				Expect(err).NotTo(HaveOccurred())
+				errorClient := redis.NewClient(&redis.Options{Addr: errorMr.Addr()})
+				errorSut := store.NewRedisIdempotencyStore(errorClient, 1*time.Minute)
+				errorMr.Close() // Close before the call to force a connection error
+
+				ok, setErr := errorSut.SetNX(ctx, "key", []byte("v"))
+
+				Expect(ok).To(BeFalse())
+				Expect(setErr).To(HaveOccurred())
+			})
+		})
+	})
+})
+
+var _ = Describe("NoOpIdempotencyStore", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+		sut    *store.NoOpIdempotencyStore
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		sut = store.NewNoOpIdempotencyStore()
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+		Context("Get", func() {
+			It("always returns nil, false, nil", func() {
+				val, hit, err := sut.Get(ctx, "any-key")
+
+				Expect(val).To(BeNil())
+				Expect(hit).To(BeFalse())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("SetNX", func() {
+			It("always returns true, nil", func() {
+				ok, err := sut.SetNX(ctx, "any-key", []byte("v"))
+
+				Expect(ok).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/internal/store/store_suite_test.go
+++ b/internal/store/store_suite_test.go
@@ -1,0 +1,13 @@
+package store_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Store Suite")
+}


### PR DESCRIPTION
## Summary

- Updates `IdempotencyStore` interface: `Get` now returns `([]byte, bool, error)` with an explicit hit/miss bool; `SetNX` drops the `ttl` parameter (TTL is now a constructor-time concern)
- `NoOpIdempotencyStore.SetNX` returns `(true, nil)` — signals "written successfully" instead of v0.3's `(false, nil)`
- Adds `RedisIdempotencyStore` backed by `go-redis/v9`; TTL fixed at construction; `redis.Nil` mapped to miss via `errors.Is`; `SetNX` uses atomic check-and-set with the construction-time TTL
- Bootstraps `store_suite_test.go`; adds `redis_test.go` with miniredis integration tests covering hit, miss, error, TTL assertion, and concurrent-write (key-already-exists) cases

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/store/... -coverpkg=./internal/store/...` — `ok`, 100% coverage (floor: 85%)
- [x] CI green