### PR TITLE
feat(store): wire RedisIdempotencyStore and set 24h TTL default

### DIFF
--- a/cmd/token-engine/main.go
+++ b/cmd/token-engine/main.go
@@ -118,7 +118,7 @@ func main() {
 	auth := interceptor.NewStaticKeyAuthenticator(cfg.StaticCallerKeys)
 
 	// ===== Stores =====
-	idempStore := store.NewNoOpIdempotencyStore()
+	idempStore := store.NewRedisIdempotencyStore(redisClient, cfg.IdempotencyTTL)
 
 	// ===== Registries =====
 	callerReg := registry.NewStaticCallerRegistry(logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	OTLPEndpoint string
 
 	// IdempotencyTTL is the TTL for idempotency store entries.
-	// env: TOKEN_ENGINE_IDEMPOTENCY_TTL; default: 5 * time.Minute
+	// env: TOKEN_ENGINE_IDEMPOTENCY_TTL; default: 24 * time.Hour
 	// parse failure — log warning, use default
 	IdempotencyTTL time.Duration
 
@@ -177,7 +177,7 @@ func Load() (*Config, error) {
 	c.RedisPassword = redisPasswordEnv
 
 	// ===== STEP 4: Parse duration fields (with warnings on failure) =====
-	defaultIdempotencyTTL := 5 * time.Minute
+	defaultIdempotencyTTL := 24 * time.Hour
 	if idempotencyTTLEnv == "" {
 		c.IdempotencyTTL = defaultIdempotencyTTL
 	} else {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,14 +129,42 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("TOKEN_ENGINE_IDEMPOTENCY_TTL parse failure", func() {
-		It("logs warning and uses default 5m", func() {
+		It("logs warning and uses default 24h", func() {
 			setRequiredEnvVars()
 			os.Setenv("TOKEN_ENGINE_IDEMPOTENCY_TTL", "not-a-duration")
 
 			cfg, err := config.Load()
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.IdempotencyTTL).To(Equal(5 * time.Minute))
+			Expect(cfg.IdempotencyTTL).To(Equal(24 * time.Hour))
+
+			cleanupEnvVars()
+		})
+	})
+
+	Context("TOKEN_ENGINE_IDEMPOTENCY_TTL set to valid duration", func() {
+		It("parses and stores the duration", func() {
+			setRequiredEnvVars()
+			os.Setenv("TOKEN_ENGINE_IDEMPOTENCY_TTL", "30m")
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.IdempotencyTTL).To(Equal(30 * time.Minute))
+
+			cleanupEnvVars()
+		})
+	})
+
+	Context("TOKEN_ENGINE_IDEMPOTENCY_TTL absent", func() {
+		It("uses default of 24h without logging a warning", func() {
+			setRequiredEnvVars()
+			// TOKEN_ENGINE_IDEMPOTENCY_TTL not set — cleanupEnvVars already unsets it
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.IdempotencyTTL).To(Equal(24 * time.Hour))
 
 			cleanupEnvVars()
 		})


### PR DESCRIPTION
## Summary

- Replaces `NoOpIdempotencyStore` in `main.go` with `RedisIdempotencyStore(redisClient, cfg.IdempotencyTTL)` — live Redis-backed at-most-once enforcement now active
- Changes `defaultIdempotencyTTL` from `5m` → `24h` per v0.4 spec (matches typical token lifetime)
- Adds config test coverage for valid-duration override and absent-env-var default cases; coverage holds at 90.3%

## Test plan

- [x] `go build ./...` — pass
- [x] `CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /dev/null ./cmd/token-engine` — pass (Docker build flags)
- [x] `go vet ./...` — silence
- [x] `go test ./...` — all packages `ok`, no FAIL lines
- [x] Config coverage >= 85%: actual 90.3%

## Phase packets

PHASE-7: `token-engine/v0.4/specs/PHASE-7.md`
PHASE-8: `token-engine/v0.4/specs/PHASE-8.md`