### PR TITLE
feat(v0.5): add RevokeAllForUserAndAudience RPC and TLS/caller-registry config fields

### DIFF
--- a/gen/v1/token_engine.pb.go
+++ b/gen/v1/token_engine.pb.go
@@ -321,6 +321,66 @@ func (x *RevokeUserRequest) GetTenantId() string {
 	return ""
 }
 
+type RevokeUserAndAudienceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Audience      string                 `protobuf:"bytes,2,opt,name=audience,proto3" json:"audience,omitempty"`
+	TenantId      string                 `protobuf:"bytes,3,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeUserAndAudienceRequest) Reset() {
+	*x = RevokeUserAndAudienceRequest{}
+	mi := &file_token_engine_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeUserAndAudienceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeUserAndAudienceRequest) ProtoMessage() {}
+
+func (x *RevokeUserAndAudienceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_token_engine_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeUserAndAudienceRequest.ProtoReflect.Descriptor instead.
+func (*RevokeUserAndAudienceRequest) Descriptor() ([]byte, []int) {
+	return file_token_engine_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *RevokeUserAndAudienceRequest) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *RevokeUserAndAudienceRequest) GetAudience() string {
+	if x != nil {
+		return x.Audience
+	}
+	return ""
+}
+
+func (x *RevokeUserAndAudienceRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
 type TokenPair struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	AccessToken           string                 `protobuf:"bytes,1,opt,name=access_token,json=accessToken,proto3" json:"access_token,omitempty"`
@@ -333,7 +393,7 @@ type TokenPair struct {
 
 func (x *TokenPair) Reset() {
 	*x = TokenPair{}
-	mi := &file_token_engine_proto_msgTypes[5]
+	mi := &file_token_engine_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -345,7 +405,7 @@ func (x *TokenPair) String() string {
 func (*TokenPair) ProtoMessage() {}
 
 func (x *TokenPair) ProtoReflect() protoreflect.Message {
-	mi := &file_token_engine_proto_msgTypes[5]
+	mi := &file_token_engine_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -358,7 +418,7 @@ func (x *TokenPair) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenPair.ProtoReflect.Descriptor instead.
 func (*TokenPair) Descriptor() ([]byte, []int) {
-	return file_token_engine_proto_rawDescGZIP(), []int{5}
+	return file_token_engine_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *TokenPair) GetAccessToken() string {
@@ -397,7 +457,7 @@ type RevokeTokenResponse struct {
 
 func (x *RevokeTokenResponse) Reset() {
 	*x = RevokeTokenResponse{}
-	mi := &file_token_engine_proto_msgTypes[6]
+	mi := &file_token_engine_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -409,7 +469,7 @@ func (x *RevokeTokenResponse) String() string {
 func (*RevokeTokenResponse) ProtoMessage() {}
 
 func (x *RevokeTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_token_engine_proto_msgTypes[6]
+	mi := &file_token_engine_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -422,7 +482,7 @@ func (x *RevokeTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeTokenResponse.ProtoReflect.Descriptor instead.
 func (*RevokeTokenResponse) Descriptor() ([]byte, []int) {
-	return file_token_engine_proto_rawDescGZIP(), []int{6}
+	return file_token_engine_proto_rawDescGZIP(), []int{7}
 }
 
 var File_token_engine_proto protoreflect.FileDescriptor
@@ -455,20 +515,25 @@ const file_token_engine_proto_rawDesc = "" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"I\n" +
 	"\x11RevokeUserRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1b\n" +
-	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"\xc3\x01\n" +
+	"\ttenant_id\x18\x02 \x01(\tR\btenantId\"p\n" +
+	"\x1cRevokeUserAndAudienceRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1a\n" +
+	"\baudience\x18\x02 \x01(\tR\baudience\x12\x1b\n" +
+	"\ttenant_id\x18\x03 \x01(\tR\btenantId\"\xc3\x01\n" +
 	"\tTokenPair\x12!\n" +
 	"\faccess_token\x18\x01 \x01(\tR\vaccessToken\x12#\n" +
 	"\rrefresh_token\x18\x02 \x01(\tR\frefreshToken\x125\n" +
 	"\x17access_token_expires_in\x18\x03 \x01(\x03R\x14accessTokenExpiresIn\x127\n" +
 	"\x18refresh_token_expires_in\x18\x04 \x01(\x03R\x15refreshTokenExpiresIn\"\x15\n" +
-	"\x13RevokeTokenResponse2\x88\x03\n" +
+	"\x13RevokeTokenResponse2\xee\x03\n" +
 	"\vTokenEngine\x12>\n" +
 	"\n" +
 	"IssueToken\x12\x1b.token.v1.IssueTokenRequest\x1a\x13.token.v1.TokenPair\x12B\n" +
 	"\fRefreshToken\x12\x1d.token.v1.RefreshTokenRequest\x1a\x13.token.v1.TokenPair\x12J\n" +
 	"\vRevokeToken\x12\x1c.token.v1.RevokeTokenRequest\x1a\x1d.token.v1.RevokeTokenResponse\x12V\n" +
 	"\x14RevokeAllForAudience\x12\x1f.token.v1.RevokeAudienceRequest\x1a\x1d.token.v1.RevokeTokenResponse\x12Q\n" +
-	"\x13RevokeAllUserTokens\x12\x1b.token.v1.RevokeUserRequest\x1a\x1d.token.v1.RevokeTokenResponseB1Z/github.com/aetomala/token-engine/gen/v1;tokenv1b\x06proto3"
+	"\x13RevokeAllUserTokens\x12\x1b.token.v1.RevokeUserRequest\x1a\x1d.token.v1.RevokeTokenResponse\x12d\n" +
+	"\x1bRevokeAllForUserAndAudience\x12&.token.v1.RevokeUserAndAudienceRequest\x1a\x1d.token.v1.RevokeTokenResponseB1Z/github.com/aetomala/token-engine/gen/v1;tokenv1b\x06proto3"
 
 var (
 	file_token_engine_proto_rawDescOnce sync.Once
@@ -482,33 +547,36 @@ func file_token_engine_proto_rawDescGZIP() []byte {
 	return file_token_engine_proto_rawDescData
 }
 
-var file_token_engine_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_token_engine_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_token_engine_proto_goTypes = []any{
-	(*IssueTokenRequest)(nil),     // 0: token.v1.IssueTokenRequest
-	(*RefreshTokenRequest)(nil),   // 1: token.v1.RefreshTokenRequest
-	(*RevokeTokenRequest)(nil),    // 2: token.v1.RevokeTokenRequest
-	(*RevokeAudienceRequest)(nil), // 3: token.v1.RevokeAudienceRequest
-	(*RevokeUserRequest)(nil),     // 4: token.v1.RevokeUserRequest
-	(*TokenPair)(nil),             // 5: token.v1.TokenPair
-	(*RevokeTokenResponse)(nil),   // 6: token.v1.RevokeTokenResponse
-	nil,                           // 7: token.v1.IssueTokenRequest.ClaimsEntry
-	nil,                           // 8: token.v1.RefreshTokenRequest.ClaimsEntry
+	(*IssueTokenRequest)(nil),            // 0: token.v1.IssueTokenRequest
+	(*RefreshTokenRequest)(nil),          // 1: token.v1.RefreshTokenRequest
+	(*RevokeTokenRequest)(nil),           // 2: token.v1.RevokeTokenRequest
+	(*RevokeAudienceRequest)(nil),        // 3: token.v1.RevokeAudienceRequest
+	(*RevokeUserRequest)(nil),            // 4: token.v1.RevokeUserRequest
+	(*RevokeUserAndAudienceRequest)(nil), // 5: token.v1.RevokeUserAndAudienceRequest
+	(*TokenPair)(nil),                    // 6: token.v1.TokenPair
+	(*RevokeTokenResponse)(nil),          // 7: token.v1.RevokeTokenResponse
+	nil,                                  // 8: token.v1.IssueTokenRequest.ClaimsEntry
+	nil,                                  // 9: token.v1.RefreshTokenRequest.ClaimsEntry
 }
 var file_token_engine_proto_depIdxs = []int32{
-	7, // 0: token.v1.IssueTokenRequest.claims:type_name -> token.v1.IssueTokenRequest.ClaimsEntry
-	8, // 1: token.v1.RefreshTokenRequest.claims:type_name -> token.v1.RefreshTokenRequest.ClaimsEntry
+	8, // 0: token.v1.IssueTokenRequest.claims:type_name -> token.v1.IssueTokenRequest.ClaimsEntry
+	9, // 1: token.v1.RefreshTokenRequest.claims:type_name -> token.v1.RefreshTokenRequest.ClaimsEntry
 	0, // 2: token.v1.TokenEngine.IssueToken:input_type -> token.v1.IssueTokenRequest
 	1, // 3: token.v1.TokenEngine.RefreshToken:input_type -> token.v1.RefreshTokenRequest
 	2, // 4: token.v1.TokenEngine.RevokeToken:input_type -> token.v1.RevokeTokenRequest
 	3, // 5: token.v1.TokenEngine.RevokeAllForAudience:input_type -> token.v1.RevokeAudienceRequest
 	4, // 6: token.v1.TokenEngine.RevokeAllUserTokens:input_type -> token.v1.RevokeUserRequest
-	5, // 7: token.v1.TokenEngine.IssueToken:output_type -> token.v1.TokenPair
-	5, // 8: token.v1.TokenEngine.RefreshToken:output_type -> token.v1.TokenPair
-	6, // 9: token.v1.TokenEngine.RevokeToken:output_type -> token.v1.RevokeTokenResponse
-	6, // 10: token.v1.TokenEngine.RevokeAllForAudience:output_type -> token.v1.RevokeTokenResponse
-	6, // 11: token.v1.TokenEngine.RevokeAllUserTokens:output_type -> token.v1.RevokeTokenResponse
-	7, // [7:12] is the sub-list for method output_type
-	2, // [2:7] is the sub-list for method input_type
+	5, // 7: token.v1.TokenEngine.RevokeAllForUserAndAudience:input_type -> token.v1.RevokeUserAndAudienceRequest
+	6, // 8: token.v1.TokenEngine.IssueToken:output_type -> token.v1.TokenPair
+	6, // 9: token.v1.TokenEngine.RefreshToken:output_type -> token.v1.TokenPair
+	7, // 10: token.v1.TokenEngine.RevokeToken:output_type -> token.v1.RevokeTokenResponse
+	7, // 11: token.v1.TokenEngine.RevokeAllForAudience:output_type -> token.v1.RevokeTokenResponse
+	7, // 12: token.v1.TokenEngine.RevokeAllUserTokens:output_type -> token.v1.RevokeTokenResponse
+	7, // 13: token.v1.TokenEngine.RevokeAllForUserAndAudience:output_type -> token.v1.RevokeTokenResponse
+	8, // [8:14] is the sub-list for method output_type
+	2, // [2:8] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -525,7 +593,7 @@ func file_token_engine_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_token_engine_proto_rawDesc), len(file_token_engine_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/v1/token_engine_grpc.pb.go
+++ b/gen/v1/token_engine_grpc.pb.go
@@ -19,11 +19,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TokenEngine_IssueToken_FullMethodName           = "/token.v1.TokenEngine/IssueToken"
-	TokenEngine_RefreshToken_FullMethodName         = "/token.v1.TokenEngine/RefreshToken"
-	TokenEngine_RevokeToken_FullMethodName          = "/token.v1.TokenEngine/RevokeToken"
-	TokenEngine_RevokeAllForAudience_FullMethodName = "/token.v1.TokenEngine/RevokeAllForAudience"
-	TokenEngine_RevokeAllUserTokens_FullMethodName  = "/token.v1.TokenEngine/RevokeAllUserTokens"
+	TokenEngine_IssueToken_FullMethodName                  = "/token.v1.TokenEngine/IssueToken"
+	TokenEngine_RefreshToken_FullMethodName                = "/token.v1.TokenEngine/RefreshToken"
+	TokenEngine_RevokeToken_FullMethodName                 = "/token.v1.TokenEngine/RevokeToken"
+	TokenEngine_RevokeAllForAudience_FullMethodName        = "/token.v1.TokenEngine/RevokeAllForAudience"
+	TokenEngine_RevokeAllUserTokens_FullMethodName         = "/token.v1.TokenEngine/RevokeAllUserTokens"
+	TokenEngine_RevokeAllForUserAndAudience_FullMethodName = "/token.v1.TokenEngine/RevokeAllForUserAndAudience"
 )
 
 // TokenEngineClient is the client API for TokenEngine service.
@@ -35,6 +36,7 @@ type TokenEngineClient interface {
 	RevokeToken(ctx context.Context, in *RevokeTokenRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
 	RevokeAllForAudience(ctx context.Context, in *RevokeAudienceRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
 	RevokeAllUserTokens(ctx context.Context, in *RevokeUserRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
+	RevokeAllForUserAndAudience(ctx context.Context, in *RevokeUserAndAudienceRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
 }
 
 type tokenEngineClient struct {
@@ -95,6 +97,16 @@ func (c *tokenEngineClient) RevokeAllUserTokens(ctx context.Context, in *RevokeU
 	return out, nil
 }
 
+func (c *tokenEngineClient) RevokeAllForUserAndAudience(ctx context.Context, in *RevokeUserAndAudienceRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RevokeTokenResponse)
+	err := c.cc.Invoke(ctx, TokenEngine_RevokeAllForUserAndAudience_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TokenEngineServer is the server API for TokenEngine service.
 // All implementations must embed UnimplementedTokenEngineServer
 // for forward compatibility.
@@ -104,6 +116,7 @@ type TokenEngineServer interface {
 	RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error)
 	RevokeAllForAudience(context.Context, *RevokeAudienceRequest) (*RevokeTokenResponse, error)
 	RevokeAllUserTokens(context.Context, *RevokeUserRequest) (*RevokeTokenResponse, error)
+	RevokeAllForUserAndAudience(context.Context, *RevokeUserAndAudienceRequest) (*RevokeTokenResponse, error)
 	mustEmbedUnimplementedTokenEngineServer()
 }
 
@@ -128,6 +141,9 @@ func (UnimplementedTokenEngineServer) RevokeAllForAudience(context.Context, *Rev
 }
 func (UnimplementedTokenEngineServer) RevokeAllUserTokens(context.Context, *RevokeUserRequest) (*RevokeTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RevokeAllUserTokens not implemented")
+}
+func (UnimplementedTokenEngineServer) RevokeAllForUserAndAudience(context.Context, *RevokeUserAndAudienceRequest) (*RevokeTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RevokeAllForUserAndAudience not implemented")
 }
 func (UnimplementedTokenEngineServer) mustEmbedUnimplementedTokenEngineServer() {}
 func (UnimplementedTokenEngineServer) testEmbeddedByValue()                     {}
@@ -240,6 +256,24 @@ func _TokenEngine_RevokeAllUserTokens_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TokenEngine_RevokeAllForUserAndAudience_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RevokeUserAndAudienceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TokenEngineServer).RevokeAllForUserAndAudience(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TokenEngine_RevokeAllForUserAndAudience_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TokenEngineServer).RevokeAllForUserAndAudience(ctx, req.(*RevokeUserAndAudienceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TokenEngine_ServiceDesc is the grpc.ServiceDesc for TokenEngine service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -266,6 +300,10 @@ var TokenEngine_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RevokeAllUserTokens",
 			Handler:    _TokenEngine_RevokeAllUserTokens_Handler,
+		},
+		{
+			MethodName: "RevokeAllForUserAndAudience",
+			Handler:    _TokenEngine_RevokeAllForUserAndAudience_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,30 @@ type Config struct {
 	// parse failure or empty map when TLSMode=="disabled" — log error and os.Exit(1)
 	StaticCallerKeys map[string]string
 
+	// TLSCertFile is the path to the service's TLS certificate file (PEM).
+	// env: TOKEN_ENGINE_TLS_CERT_FILE; no default
+	// absent when TLSMode == "mtls" — log error and os.Exit(1)
+	// ignored when TLSMode == "disabled"
+	TLSCertFile string
+
+	// TLSKeyFile is the path to the service's TLS private key file (PEM).
+	// env: TOKEN_ENGINE_TLS_KEY_FILE; no default
+	// absent when TLSMode == "mtls" — log error and os.Exit(1)
+	// ignored when TLSMode == "disabled"
+	TLSKeyFile string
+
+	// TLSCAFile is the path to the CA certificate file for client certificate verification (PEM).
+	// env: TOKEN_ENGINE_TLS_CA_FILE; no default
+	// absent when TLSMode == "mtls" — log error and os.Exit(1)
+	// ignored when TLSMode == "disabled"
+	TLSCAFile string
+
+	// CallerRegistryPath is the filesystem path to the caller-registry YAML file.
+	// env: TOKEN_ENGINE_CALLER_REGISTRY_PATH; no default
+	// absent when TLSMode == "mtls" — log error and os.Exit(1)
+	// optional when TLSMode == "disabled" — empty string is valid when disabled
+	CallerRegistryPath string
+
 	// RedisAddr is the Redis server address.
 	// env: TOKEN_ENGINE_REDIS_ADDR; default: "localhost:6379"
 	// parse failure — log warning, use default
@@ -103,6 +127,10 @@ func Load() (*Config, error) {
 	maxConnectionAgeEnv := os.Getenv("TOKEN_ENGINE_MAX_CONNECTION_AGE")
 	maxConnectionAgeGraceEnv := os.Getenv("TOKEN_ENGINE_MAX_CONNECTION_AGE_GRACE")
 	staticCallerKeysEnv := os.Getenv("TOKEN_ENGINE_STATIC_CALLER_KEYS")
+	tlsCertFileEnv := os.Getenv("TOKEN_ENGINE_TLS_CERT_FILE")
+	tlsKeyFileEnv := os.Getenv("TOKEN_ENGINE_TLS_KEY_FILE")
+	tlsCAFileEnv := os.Getenv("TOKEN_ENGINE_TLS_CA_FILE")
+	callerRegistryPathEnv := os.Getenv("TOKEN_ENGINE_CALLER_REGISTRY_PATH")
 	redisAddrEnv := os.Getenv("TOKEN_ENGINE_REDIS_ADDR")
 	redisPasswordEnv := os.Getenv("TOKEN_ENGINE_REDIS_PASSWORD")
 	redisDBEnv := os.Getenv("TOKEN_ENGINE_REDIS_DB")
@@ -153,6 +181,26 @@ func Load() (*Config, error) {
 	}
 	c.StaticCallerKeys = staticCallerKeys
 
+	// Validate TLS fields when TLSMode == "mtls"
+	if c.TLSMode == "mtls" {
+		if tlsCertFileEnv == "" {
+			log.Printf("TOKEN_ENGINE_TLS_CERT_FILE must not be empty when TLSMode is mtls")
+			os.Exit(1)
+		}
+		if tlsKeyFileEnv == "" {
+			log.Printf("TOKEN_ENGINE_TLS_KEY_FILE must not be empty when TLSMode is mtls")
+			os.Exit(1)
+		}
+		if tlsCAFileEnv == "" {
+			log.Printf("TOKEN_ENGINE_TLS_CA_FILE must not be empty when TLSMode is mtls")
+			os.Exit(1)
+		}
+		if callerRegistryPathEnv == "" {
+			log.Printf("TOKEN_ENGINE_CALLER_REGISTRY_PATH must not be empty when TLSMode is mtls")
+			os.Exit(1)
+		}
+	}
+
 	// ===== STEP 3: Apply string defaults =====
 	if grpcAddrEnv == "" {
 		c.GRPCAddr = ":9090"
@@ -167,6 +215,11 @@ func Load() (*Config, error) {
 	}
 
 	c.OTLPEndpoint = otlpEndpointEnv
+
+	c.TLSCertFile = tlsCertFileEnv
+	c.TLSKeyFile = tlsKeyFileEnv
+	c.TLSCAFile = tlsCAFileEnv
+	c.CallerRegistryPath = callerRegistryPathEnv
 
 	if redisAddrEnv == "" {
 		c.RedisAddr = "localhost:6379"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,10 @@ var _ = Describe("Config", func() {
 		os.Unsetenv("TOKEN_ENGINE_REDIS_PASSWORD")
 		os.Unsetenv("TOKEN_ENGINE_REDIS_DB")
 		os.Unsetenv("TOKEN_ENGINE_JWKS_CACHE_MAX_AGE")
+		os.Unsetenv("TOKEN_ENGINE_TLS_CERT_FILE")
+		os.Unsetenv("TOKEN_ENGINE_TLS_KEY_FILE")
+		os.Unsetenv("TOKEN_ENGINE_TLS_CA_FILE")
+		os.Unsetenv("TOKEN_ENGINE_CALLER_REGISTRY_PATH")
 	}
 
 	AfterEach(func() {
@@ -245,6 +249,133 @@ var _ = Describe("Config", func() {
 				"key1": "caller1",
 			}))
 			Expect(cfg.StaticCallerKeys).NotTo(BeEmpty())
+
+			cleanupEnvVars()
+		})
+	})
+	Context("when TLSMode is 'mtls' and all TLS fields are present", func() {
+		It("stores TLSCertFile, TLSKeyFile, TLSCAFile, CallerRegistryPath", func() {
+			os.Setenv("TOKEN_ENGINE_ISSUER", "required-issuer")
+			os.Setenv("TOKEN_ENGINE_AUDIENCE", "required-audience")
+			os.Setenv("TOKEN_ENGINE_TLS_MODE", "mtls")
+			os.Setenv("TOKEN_ENGINE_TLS_CERT_FILE", "/path/to/cert.pem")
+			os.Setenv("TOKEN_ENGINE_TLS_KEY_FILE", "/path/to/key.pem")
+			os.Setenv("TOKEN_ENGINE_TLS_CA_FILE", "/path/to/ca.pem")
+			os.Setenv("TOKEN_ENGINE_CALLER_REGISTRY_PATH", "/path/to/caller-registry.yaml")
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.TLSCertFile).To(Equal("/path/to/cert.pem"))
+			Expect(cfg.TLSKeyFile).To(Equal("/path/to/key.pem"))
+			Expect(cfg.TLSCAFile).To(Equal("/path/to/ca.pem"))
+			Expect(cfg.CallerRegistryPath).To(Equal("/path/to/caller-registry.yaml"))
+
+			cleanupEnvVars()
+		})
+	})
+
+	Context("when TLSMode is 'mtls' and TOKEN_ENGINE_TLS_CERT_FILE is absent", func() {
+		It("logs error and exits 1", func() {
+			if os.Getenv("TEST_SUBPROCESS") == "mtls_cert_file_absent" {
+				os.Setenv("TOKEN_ENGINE_ISSUER", "required-issuer")
+				os.Setenv("TOKEN_ENGINE_AUDIENCE", "required-audience")
+				os.Setenv("TOKEN_ENGINE_TLS_MODE", "mtls")
+				os.Setenv("TOKEN_ENGINE_TLS_KEY_FILE", "/path/to/key.pem")
+				os.Setenv("TOKEN_ENGINE_TLS_CA_FILE", "/path/to/ca.pem")
+				os.Setenv("TOKEN_ENGINE_CALLER_REGISTRY_PATH", "/path/to/caller-registry.yaml")
+				config.Load()
+				return
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=TestConfig")
+			cmd.Env = append(os.Environ(), "TEST_SUBPROCESS=mtls_cert_file_absent")
+			err := cmd.Run()
+
+			var exitErr *exec.ExitError
+			Expect(errors.As(err, &exitErr)).To(BeTrue())
+			Expect(exitErr.ExitCode()).To(Equal(1))
+		})
+	})
+
+	Context("when TLSMode is 'mtls' and TOKEN_ENGINE_TLS_KEY_FILE is absent", func() {
+		It("logs error and exits 1", func() {
+			if os.Getenv("TEST_SUBPROCESS") == "mtls_key_file_absent" {
+				os.Setenv("TOKEN_ENGINE_ISSUER", "required-issuer")
+				os.Setenv("TOKEN_ENGINE_AUDIENCE", "required-audience")
+				os.Setenv("TOKEN_ENGINE_TLS_MODE", "mtls")
+				os.Setenv("TOKEN_ENGINE_TLS_CERT_FILE", "/path/to/cert.pem")
+				os.Setenv("TOKEN_ENGINE_TLS_CA_FILE", "/path/to/ca.pem")
+				os.Setenv("TOKEN_ENGINE_CALLER_REGISTRY_PATH", "/path/to/caller-registry.yaml")
+				config.Load()
+				return
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=TestConfig")
+			cmd.Env = append(os.Environ(), "TEST_SUBPROCESS=mtls_key_file_absent")
+			err := cmd.Run()
+
+			var exitErr *exec.ExitError
+			Expect(errors.As(err, &exitErr)).To(BeTrue())
+			Expect(exitErr.ExitCode()).To(Equal(1))
+		})
+	})
+
+	Context("when TLSMode is 'mtls' and TOKEN_ENGINE_TLS_CA_FILE is absent", func() {
+		It("logs error and exits 1", func() {
+			if os.Getenv("TEST_SUBPROCESS") == "mtls_ca_file_absent" {
+				os.Setenv("TOKEN_ENGINE_ISSUER", "required-issuer")
+				os.Setenv("TOKEN_ENGINE_AUDIENCE", "required-audience")
+				os.Setenv("TOKEN_ENGINE_TLS_MODE", "mtls")
+				os.Setenv("TOKEN_ENGINE_TLS_CERT_FILE", "/path/to/cert.pem")
+				os.Setenv("TOKEN_ENGINE_TLS_KEY_FILE", "/path/to/key.pem")
+				os.Setenv("TOKEN_ENGINE_CALLER_REGISTRY_PATH", "/path/to/caller-registry.yaml")
+				config.Load()
+				return
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=TestConfig")
+			cmd.Env = append(os.Environ(), "TEST_SUBPROCESS=mtls_ca_file_absent")
+			err := cmd.Run()
+
+			var exitErr *exec.ExitError
+			Expect(errors.As(err, &exitErr)).To(BeTrue())
+			Expect(exitErr.ExitCode()).To(Equal(1))
+		})
+	})
+
+	Context("when TLSMode is 'mtls' and TOKEN_ENGINE_CALLER_REGISTRY_PATH is absent", func() {
+		It("logs error and exits 1", func() {
+			if os.Getenv("TEST_SUBPROCESS") == "mtls_caller_registry_absent" {
+				os.Setenv("TOKEN_ENGINE_ISSUER", "required-issuer")
+				os.Setenv("TOKEN_ENGINE_AUDIENCE", "required-audience")
+				os.Setenv("TOKEN_ENGINE_TLS_MODE", "mtls")
+				os.Setenv("TOKEN_ENGINE_TLS_CERT_FILE", "/path/to/cert.pem")
+				os.Setenv("TOKEN_ENGINE_TLS_KEY_FILE", "/path/to/key.pem")
+				os.Setenv("TOKEN_ENGINE_TLS_CA_FILE", "/path/to/ca.pem")
+				config.Load()
+				return
+			}
+
+			cmd := exec.Command(os.Args[0], "-test.run=TestConfig")
+			cmd.Env = append(os.Environ(), "TEST_SUBPROCESS=mtls_caller_registry_absent")
+			err := cmd.Run()
+
+			var exitErr *exec.ExitError
+			Expect(errors.As(err, &exitErr)).To(BeTrue())
+			Expect(exitErr.ExitCode()).To(Equal(1))
+		})
+	})
+
+	Context("when TLSMode is 'disabled' and TOKEN_ENGINE_CALLER_REGISTRY_PATH is absent", func() {
+		It("stores empty CallerRegistryPath without error", func() {
+			setRequiredEnvVars()
+			// TOKEN_ENGINE_CALLER_REGISTRY_PATH not set
+
+			cfg, err := config.Load()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CallerRegistryPath).To(Equal(""))
 
 			cleanupEnvVars()
 		})

--- a/proto/token_engine.proto
+++ b/proto/token_engine.proto
@@ -10,6 +10,7 @@ service TokenEngine {
   rpc RevokeToken(RevokeTokenRequest)              returns (RevokeTokenResponse);
   rpc RevokeAllForAudience(RevokeAudienceRequest)  returns (RevokeTokenResponse);
   rpc RevokeAllUserTokens(RevokeUserRequest)        returns (RevokeTokenResponse);
+  rpc RevokeAllForUserAndAudience(RevokeUserAndAudienceRequest) returns (RevokeTokenResponse);
 }
 
 message IssueTokenRequest {
@@ -40,6 +41,16 @@ message RevokeAudienceRequest {
 message RevokeUserRequest {
   string user_id   = 1;
   string tenant_id = 2;
+}
+
+message RevokeUserAndAudienceRequest {
+  string user_id   = 1;
+  string audience  = 2;
+  string tenant_id = 3;
+  // IMPORTANT: Revocation is atomic. Revoking for a user+audience combination
+  // revokes the entire refresh token record, not just the targeted audience.
+  // If independent revocability per audience is required, issue separate tokens.
+  // See ADR-009.
 }
 
 message TokenPair {


### PR DESCRIPTION
## Summary

- Adds `RevokeAllForUserAndAudience` RPC and `RevokeUserAndAudienceRequest` message to `proto/token_engine.proto`; regenerates `gen/v1/`
- Adds four new `Config` fields: `TLSCertFile`, `TLSKeyFile`, `TLSCAFile`, `CallerRegistryPath` with corresponding env vars
- Fatal validation exits 1 when `TLSMode == "mtls"` and any of the four fields is absent; all four are optional when `TLSMode == "disabled"`
- 6 new config test cases (subprocess pattern for exit-1 paths)

## Test plan

- [ ] `go build ./...` — passes (no compilation errors, grpc server interface not yet satisfied — handler added in Group 3)
- [ ] `go vet ./...` — clean
- [ ] `go test ./internal/config/... -v` — 17/17 specs pass