### PR TITLE
feat(v0.5): add MultiTenantRegistry with full lifecycle management

### DIFF
--- a/internal/registry/multi_tenant.go
+++ b/internal/registry/multi_tenant.go
@@ -1,0 +1,256 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	librarymetrics "github.com/aetomala/jwtauth/pkg/metrics"
+	"github.com/aetomala/jwtauth/pkg/keys"
+	"github.com/aetomala/jwtauth/pkg/storage"
+	"github.com/aetomala/jwtauth/pkg/tokens"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/aetomala/token-engine/internal/observability"
+)
+
+const (
+	tenantRegistryOpAdd    = "add"
+	tenantRegistryOpDrain  = "drain"
+	tenantRegistryOpRemove = "remove"
+	tenantRegistryOpLabel  = "operation"
+)
+
+type tenantEntry struct {
+	manager  tokens.TokenManager
+	km       keys.KeyManager
+	draining bool
+}
+
+// MultiTenantRegistry is a dynamic multi-tenant implementation of TenantRegistry.
+// It supports runtime Add/Drain/Remove lifecycle for per-tenant token manager stacks.
+// Each tenant gets an isolated key prefix, library namespace, and Prometheus metric namespace.
+// All methods are safe for concurrent use.
+type MultiTenantRegistry struct {
+	client  *redis.Client
+	promReg *prometheus.Registry
+	logger  observability.Logger
+	tracer  observability.Tracer
+	metrics observability.Metrics
+	mu      sync.RWMutex
+	tenants map[string]*tenantEntry
+}
+
+var _ TenantRegistry = (*MultiTenantRegistry)(nil)
+
+// NewMultiTenantRegistry returns a new, empty MultiTenantRegistry. The caller is
+// responsible for calling Add before any Get calls.
+func NewMultiTenantRegistry(
+	client *redis.Client,
+	promReg *prometheus.Registry,
+	logger observability.Logger,
+	tracer observability.Tracer,
+	metrics observability.Metrics,
+) *MultiTenantRegistry {
+	return &MultiTenantRegistry{
+		client:  client,
+		promReg: promReg,
+		logger:  logger,
+		tracer:  tracer,
+		metrics: metrics,
+		tenants: make(map[string]*tenantEntry),
+	}
+}
+
+// Add constructs and registers a new tenant stack — KeyStore, KeyManager, RefreshStore, and TokenManager.
+// Starts the TokenManager (which internally starts the KeyManager) before returning.
+// Returns codes.InvalidArgument if tenantID, cfg.Issuer, or cfg.Audience is "".
+// Returns codes.AlreadyExists if tenantID is already registered.
+func (r *MultiTenantRegistry) Add(ctx context.Context, tenantID string, cfg TenantConfig) error {
+	// ===== STEP 1: Validate inputs (no lock) =====
+	if tenantID == "" {
+		return status.Error(codes.InvalidArgument, "tenantID must not be empty")
+	}
+	if cfg.Issuer == "" {
+		return status.Error(codes.InvalidArgument, "cfg.Issuer must not be empty")
+	}
+	if cfg.Audience == "" {
+		return status.Error(codes.InvalidArgument, "cfg.Audience must not be empty")
+	}
+
+	// ===== STEP 2: Acquire write lock =====
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// ===== STEP 3: Check AlreadyExists =====
+	if _, exists := r.tenants[tenantID]; exists {
+		return status.Errorf(codes.AlreadyExists, "tenant %s is already registered", tenantID)
+	}
+
+	// ===== STEP 4: Build per-tenant stack =====
+	keyStore, err := keys.NewRedisKeyStore(keys.RedisKeyStoreConfig{
+		Client:    r.client,
+		KeyPrefix: tenantID,
+		Logger:    observability.NewLibraryLoggerAdapter(r.logger),
+	})
+	if err != nil {
+		return fmt.Errorf("creating redis key store for tenant %s: %w", tenantID, err)
+	}
+
+	km, err := keys.NewManager(keys.KeyManagerConfig{
+		KeyStore:  keyStore,
+		Namespace: tenantID,
+		Logger:    observability.NewLibraryLoggerAdapter(r.logger),
+	})
+	if err != nil {
+		return fmt.Errorf("creating key manager for tenant %s: %w", tenantID, err)
+	}
+
+	refreshStore, err := storage.NewRedisRefreshStore(storage.RedisRefreshStoreConfig{
+		Client:    r.client,
+		KeyPrefix: tenantID,
+		Logger:    observability.NewLibraryLoggerAdapter(r.logger),
+	})
+	if err != nil {
+		return fmt.Errorf("creating redis refresh store for tenant %s: %w", tenantID, err)
+	}
+
+	manager, err := tokens.NewManager(tokens.TokenManagerConfig{
+		KeyManager:   km,
+		RefreshStore: refreshStore,
+		Logger:       observability.NewLibraryLoggerAdapter(r.logger),
+		Metrics: librarymetrics.NewPrometheusMetrics(librarymetrics.PrometheusConfig{
+			Registry:  r.promReg,
+			Namespace: tenantID,
+		}),
+		Namespace: tenantID,
+		Issuer:    cfg.Issuer,
+		Audience:  []string{cfg.Audience},
+	})
+	if err != nil {
+		return fmt.Errorf("creating token manager for tenant %s: %w", tenantID, err)
+	}
+
+	if err := manager.Start(ctx); err != nil {
+		return fmt.Errorf("starting token manager for tenant %s: %w", tenantID, err)
+	}
+
+	// ===== STEP 5: Register entry =====
+	r.tenants[tenantID] = &tenantEntry{
+		manager:  manager,
+		km:       km,
+		draining: false,
+	}
+
+	// ===== STEP 6: Emit metrics =====
+	r.metrics.SetGauge(observability.MetricActiveTenants, float64(len(r.tenants)), nil)
+	r.metrics.IncrementCounter(observability.MetricRegistryOps, map[string]string{tenantRegistryOpLabel: tenantRegistryOpAdd})
+
+	return nil
+}
+
+// Drain marks tenantID as draining so subsequent Get calls return codes.NotFound.
+// In-flight requests already past the registry lookup are unaffected.
+// Returns codes.InvalidArgument if tenantID is "".
+// Returns codes.NotFound if tenantID is not registered.
+func (r *MultiTenantRegistry) Drain(ctx context.Context, tenantID string) error {
+	// ===== STEP 1: Validate =====
+	if tenantID == "" {
+		return status.Error(codes.InvalidArgument, "tenantID must not be empty")
+	}
+
+	// ===== STEP 2: Acquire write lock =====
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// ===== STEP 3: Locate entry =====
+	entry, exists := r.tenants[tenantID]
+	if !exists {
+		return status.Errorf(codes.NotFound, "tenant %s not found", tenantID)
+	}
+
+	// ===== STEP 4: Mark draining =====
+	entry.draining = true
+
+	// ===== STEP 5: Emit metrics =====
+	r.metrics.IncrementCounter(observability.MetricRegistryOps, map[string]string{tenantRegistryOpLabel: tenantRegistryOpDrain})
+
+	return nil
+}
+
+// Remove stops the tenant's KeyManager and removes it from the registry.
+// Must be called only after Drain — returns codes.FailedPrecondition if the tenant is not draining.
+// Returns codes.InvalidArgument if tenantID is "".
+// Returns codes.NotFound if tenantID is not registered.
+func (r *MultiTenantRegistry) Remove(ctx context.Context, tenantID string) error {
+	// ===== STEP 1: Validate =====
+	if tenantID == "" {
+		return status.Error(codes.InvalidArgument, "tenantID must not be empty")
+	}
+
+	// ===== STEP 2: Acquire write lock =====
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// ===== STEP 3: Locate entry =====
+	entry, exists := r.tenants[tenantID]
+	if !exists {
+		return status.Errorf(codes.NotFound, "tenant %s not found", tenantID)
+	}
+
+	// ===== STEP 4: Enforce drain precondition =====
+	if !entry.draining {
+		return status.Errorf(codes.FailedPrecondition, "tenant %s must be drained before removal", tenantID)
+	}
+
+	// ===== STEP 5: Shutdown KeyManager =====
+	if err := entry.km.Shutdown(ctx); err != nil {
+		r.logger.Warn(ctx, "key manager shutdown error during tenant removal", "tenant", tenantID, "error", err)
+	}
+
+	// ===== STEP 6: Remove entry =====
+	delete(r.tenants, tenantID)
+
+	// ===== STEP 7: Emit metrics =====
+	r.metrics.SetGauge(observability.MetricActiveTenants, float64(len(r.tenants)), nil)
+	r.metrics.IncrementCounter(observability.MetricRegistryOps, map[string]string{tenantRegistryOpLabel: tenantRegistryOpRemove})
+
+	return nil
+}
+
+// Get returns the TokenManager for tenantID.
+// Returns codes.InvalidArgument if tenantID is "".
+// Returns codes.NotFound if tenantID is unknown or draining.
+func (r *MultiTenantRegistry) Get(_ context.Context, tenantID string) (tokens.TokenManager, error) {
+	// ===== STEP 1: Validate =====
+	if tenantID == "" {
+		return nil, status.Error(codes.InvalidArgument, "tenant_id must not be empty")
+	}
+
+	// ===== STEP 2: Acquire read lock =====
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// ===== STEP 3: Locate entry =====
+	entry, exists := r.tenants[tenantID]
+	if !exists || entry.draining {
+		return nil, status.Errorf(codes.NotFound, "tenant %s not found", tenantID)
+	}
+
+	return entry.manager, nil
+}
+
+// AllKeyManagers returns a snapshot of all registered tenants' KeyManagers.
+// The returned map is a defensive copy — mutations do not affect the registry.
+func (r *MultiTenantRegistry) AllKeyManagers() map[string]keys.KeyManager {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make(map[string]keys.KeyManager, len(r.tenants))
+	for id, entry := range r.tenants {
+		result[id] = entry.km
+	}
+	return result
+}

--- a/internal/registry/multi_tenant_test.go
+++ b/internal/registry/multi_tenant_test.go
@@ -1,0 +1,343 @@
+package registry_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/aetomala/token-engine/internal/observability"
+	"github.com/aetomala/token-engine/internal/registry"
+)
+
+var _ = Describe("MultiTenantRegistry", func() {
+	var (
+		ctx     context.Context
+		cancel  context.CancelFunc
+		mr      *miniredis.Miniredis
+		client  *redis.Client
+		promReg *prometheus.Registry
+		logger  observability.Logger
+		tracer  observability.Tracer
+		metrics observability.Metrics
+		reg     *registry.MultiTenantRegistry
+	)
+
+	BeforeEach(func() {
+		var err error
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		mr, err = miniredis.Run()
+		Expect(err).NotTo(HaveOccurred())
+		client = redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		promReg = prometheus.NewRegistry()
+		logger = observability.NewNoOpLogger()
+		tracer = observability.NewNoOpTracer()
+		metrics = observability.NewNoOpMetrics()
+		reg = registry.NewMultiTenantRegistry(client, promReg, logger, tracer, metrics)
+	})
+
+	AfterEach(func() {
+		cancel()
+		_ = client.Close()
+		mr.Close()
+	})
+
+	// ===== PHASE 1: Constructor and Initialization =====
+	Describe("Phase 1: Constructor and Initialization", func() {
+		Context("when constructed with valid dependencies", func() {
+			It("returns a non-nil registry", func() {
+				Expect(reg).NotTo(BeNil())
+			})
+
+			It("starts with no tenants — AllKeyManagers returns empty map", func() {
+				kms := reg.AllKeyManagers()
+				Expect(kms).To(BeEmpty())
+			})
+		})
+	})
+
+	// ===== PHASE 3: Core Operations =====
+
+	Describe("Phase 3: Core Operations — Add", func() {
+		Context("when tenant is not registered", func() {
+			It("constructs the full per-tenant stack and returns nil error", func() {
+				err := reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("makes the tenant available via Get", func() {
+				err := reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})
+				Expect(err).NotTo(HaveOccurred())
+
+				manager, getErr := reg.Get(ctx, "tenant1")
+				Expect(getErr).NotTo(HaveOccurred())
+				Expect(manager).NotTo(BeNil())
+			})
+
+			It("emits metrics without panicking", func() {
+				Expect(func() {
+					_ = reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})
+				}).NotTo(Panic())
+			})
+		})
+
+		Context("when tenant is already registered", func() {
+			It("returns codes.AlreadyExists", func() {
+				Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+
+				err := reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})
+				Expect(status.Code(err)).To(Equal(codes.AlreadyExists))
+			})
+		})
+
+		Context("when tenantID is empty", func() {
+			It("returns codes.InvalidArgument", func() {
+				err := reg.Add(ctx, "", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+
+		Context("when cfg.Issuer is empty", func() {
+			It("returns codes.InvalidArgument", func() {
+				err := reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "", Audience: "api"})
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+
+		Context("when cfg.Audience is empty", func() {
+			It("returns codes.InvalidArgument", func() {
+				err := reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: ""})
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+
+		Context("when stack construction fails", func() {
+			It("returns a wrapped error and does not register the tenant", func() {
+				badClient := redis.NewClient(&redis.Options{Addr: "localhost:1"}) // port 1 never open
+				defer badClient.Close()
+				badReg := registry.NewMultiTenantRegistry(badClient, prometheus.NewRegistry(),
+					observability.NewNoOpLogger(), observability.NewNoOpTracer(), observability.NewNoOpMetrics())
+
+				shortCtx, shortCancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer shortCancel()
+
+				err := badReg.Add(shortCtx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})
+				Expect(err).To(HaveOccurred())
+
+				_, getErr := badReg.Get(context.Background(), "tenant1")
+				Expect(status.Code(getErr)).To(Equal(codes.NotFound))
+			})
+		})
+	})
+
+	Describe("Phase 3: Core Operations — Drain", func() {
+		BeforeEach(func() {
+			Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+		})
+
+		Context("when tenant is registered and active", func() {
+			It("returns nil error", func() {
+				Expect(reg.Drain(ctx, "tenant1")).To(Succeed())
+			})
+
+			It("emits metrics without panicking", func() {
+				Expect(func() {
+					_ = reg.Drain(ctx, "tenant1")
+				}).NotTo(Panic())
+			})
+		})
+
+		Context("after Drain — Get", func() {
+			It("returns codes.NotFound", func() {
+				Expect(reg.Drain(ctx, "tenant1")).To(Succeed())
+
+				_, err := reg.Get(ctx, "tenant1")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+
+		Context("when tenantID is unknown", func() {
+			It("returns codes.NotFound", func() {
+				err := reg.Drain(ctx, "unknown-tenant")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+
+		Context("when tenantID is empty", func() {
+			It("returns codes.InvalidArgument", func() {
+				err := reg.Drain(ctx, "")
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+	})
+
+	Describe("Phase 3: Core Operations — Remove", func() {
+		BeforeEach(func() {
+			Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+		})
+
+		Context("when tenant is drained", func() {
+			BeforeEach(func() {
+				Expect(reg.Drain(ctx, "tenant1")).To(Succeed())
+			})
+
+			It("returns nil error", func() {
+				Expect(reg.Remove(ctx, "tenant1")).To(Succeed())
+			})
+
+			It("removes the entry — subsequent Get returns codes.NotFound", func() {
+				Expect(reg.Remove(ctx, "tenant1")).To(Succeed())
+
+				_, err := reg.Get(ctx, "tenant1")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+
+			It("emits metrics without panicking", func() {
+				Expect(func() {
+					_ = reg.Remove(ctx, "tenant1")
+				}).NotTo(Panic())
+			})
+		})
+
+		Context("when tenant is active — not drained", func() {
+			It("returns codes.FailedPrecondition", func() {
+				err := reg.Remove(ctx, "tenant1")
+				Expect(status.Code(err)).To(Equal(codes.FailedPrecondition))
+			})
+
+			It("does not remove the entry — subsequent Get still returns the manager", func() {
+				_ = reg.Remove(ctx, "tenant1")
+
+				manager, err := reg.Get(ctx, "tenant1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(manager).NotTo(BeNil())
+			})
+		})
+
+		Context("when tenantID is unknown", func() {
+			It("returns codes.NotFound", func() {
+				err := reg.Remove(ctx, "unknown-tenant")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+
+		Context("when tenantID is empty", func() {
+			It("returns codes.InvalidArgument", func() {
+				err := reg.Remove(ctx, "")
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+	})
+
+	Describe("Phase 3: Core Operations — Get", func() {
+		BeforeEach(func() {
+			Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+		})
+
+		Context("when tenant is active", func() {
+			It("returns the TokenManager — not nil", func() {
+				manager, err := reg.Get(ctx, "tenant1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(manager).NotTo(BeNil())
+			})
+		})
+
+		Context("when tenant is draining", func() {
+			It("returns codes.NotFound", func() {
+				Expect(reg.Drain(ctx, "tenant1")).To(Succeed())
+
+				_, err := reg.Get(ctx, "tenant1")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+
+		Context("when tenantID is unknown", func() {
+			It("returns codes.NotFound", func() {
+				_, err := reg.Get(ctx, "unknown-tenant")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+
+		Context("when tenantID is empty", func() {
+			It("returns codes.InvalidArgument", func() {
+				_, err := reg.Get(ctx, "")
+				Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+			})
+		})
+	})
+
+	Describe("Phase 3: Core Operations — AllKeyManagers", func() {
+		Context("with tenants registered", func() {
+			It("returns a map containing registered tenants", func() {
+				Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+
+				kms := reg.AllKeyManagers()
+				Expect(kms).To(HaveKey("tenant1"))
+				Expect(kms["tenant1"]).NotTo(BeNil())
+			})
+
+			It("returns a snapshot — map mutations do not affect the registry", func() {
+				Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+
+				kms := reg.AllKeyManagers()
+				Expect(kms).To(HaveKey("tenant1"))
+
+				// Mutate the returned map
+				delete(kms, "tenant1")
+
+				// Registry is unaffected
+				kms2 := reg.AllKeyManagers()
+				Expect(kms2).To(HaveKey("tenant1"))
+			})
+		})
+
+		Context("with no tenants registered", func() {
+			It("returns an empty map", func() {
+				kms := reg.AllKeyManagers()
+				Expect(kms).To(BeEmpty())
+			})
+		})
+	})
+
+	// ===== PHASE 4: Error Cases =====
+	Describe("Phase 4: Error Cases", func() {
+		Context("when adding two tenants with different IDs", func() {
+			It("both are accessible via Get", func() {
+				Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+
+				ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel2()
+				Expect(reg.Add(ctx2, "tenant2", registry.TenantConfig{Issuer: "tenant2", Audience: "api"})).To(Succeed())
+
+				m1, err1 := reg.Get(ctx, "tenant1")
+				Expect(err1).NotTo(HaveOccurred())
+				Expect(m1).NotTo(BeNil())
+
+				m2, err2 := reg.Get(ctx, "tenant2")
+				Expect(err2).NotTo(HaveOccurred())
+				Expect(m2).NotTo(BeNil())
+			})
+		})
+
+		Context("when draining a tenant that is already draining", func() {
+			It("returns nil error — drain is idempotent", func() {
+				Expect(reg.Add(ctx, "tenant1", registry.TenantConfig{Issuer: "tenant1", Audience: "api"})).To(Succeed())
+				Expect(reg.Drain(ctx, "tenant1")).To(Succeed())
+				Expect(reg.Drain(ctx, "tenant1")).To(Succeed())
+			})
+		})
+
+		Context("when removing a tenant that does not exist", func() {
+			It("returns codes.NotFound", func() {
+				err := reg.Remove(ctx, "nonexistent")
+				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+	})
+})

--- a/internal/registry/tenant.go
+++ b/internal/registry/tenant.go
@@ -18,14 +18,39 @@ import (
 	"github.com/aetomala/token-engine/internal/observability"
 )
 
-// TenantRegistry provides tenant-aware token manager lookup.
+// TenantRegistry provides tenant-aware token manager lookup and lifecycle management.
+// All methods are safe for concurrent use.
 type TenantRegistry interface {
-	// Get returns the Manager for the given tenantID.
+	// Get returns the TokenManager for tenantID.
+	// Returns codes.InvalidArgument if tenantID is "".
 	// Returns codes.NotFound if tenantID is unknown or draining.
-	// Returns codes.InvalidArgument if tenantID is empty string "".
-	// Absent tenant_id (zero-value from proto unmarshalling) routes to the default tenant —
-	// the registry receives "" only when the caller explicitly sends "".
 	Get(ctx context.Context, tenantID string) (tokens.TokenManager, error)
+
+	// Add constructs and registers a new tenant.
+	// Starts the tenant's KeyManager before returning.
+	// Returns codes.AlreadyExists if tenantID is already registered.
+	// Returns codes.InvalidArgument if tenantID is "", cfg.Issuer is "", or cfg.Audience is "".
+	Add(ctx context.Context, tenantID string, cfg TenantConfig) error
+
+	// Drain marks tenantID as draining. Subsequent Get calls return codes.NotFound.
+	// In-flight requests already past the registry lookup are unaffected.
+	// Returns codes.NotFound if tenantID is not registered.
+	// Returns codes.InvalidArgument if tenantID is "".
+	Drain(ctx context.Context, tenantID string) error
+
+	// Remove stops the tenant's KeyManager and removes it from the registry.
+	// Must be called only after Drain.
+	// Returns codes.NotFound if tenantID is not registered.
+	// Returns codes.InvalidArgument if tenantID is "".
+	Remove(ctx context.Context, tenantID string) error
+}
+
+// TenantConfig is the per-tenant configuration passed to TenantRegistry.Add.
+// Issuer is used as the Redis key prefix, library namespace, and JWT iss claim.
+// Audience is the default JWT audience for tokens issued under this tenant.
+type TenantConfig struct {
+	Issuer   string
+	Audience string
 }
 
 // ===== Constants =====
@@ -40,6 +65,8 @@ const (
 // StaticTenantRegistry is a single-tenant implementation of TenantRegistry backed by Redis.
 // It builds and owns the full jwtauth key manager and token manager stack for the configured issuer.
 // All methods are safe for concurrent use.
+var _ TenantRegistry = (*StaticTenantRegistry)(nil)
+
 type StaticTenantRegistry struct {
 	manager *tokens.Manager
 	km      keys.KeyManager
@@ -122,6 +149,22 @@ func NewStaticTenantRegistry(
 // during graceful shutdown.
 func (r *StaticTenantRegistry) KeyManager() keys.KeyManager {
 	return r.km
+}
+
+// Add returns codes.Unimplemented — StaticTenantRegistry does not support dynamic tenant management.
+// Use MultiTenantRegistry for Add/Drain/Remove lifecycle.
+func (r *StaticTenantRegistry) Add(_ context.Context, _ string, _ TenantConfig) error {
+	return status.Error(codes.Unimplemented, "Add not supported on StaticTenantRegistry — use MultiTenantRegistry")
+}
+
+// Drain returns codes.Unimplemented — StaticTenantRegistry does not support dynamic tenant management.
+func (r *StaticTenantRegistry) Drain(_ context.Context, _ string) error {
+	return status.Error(codes.Unimplemented, "Drain not supported on StaticTenantRegistry — use MultiTenantRegistry")
+}
+
+// Remove returns codes.Unimplemented — StaticTenantRegistry does not support dynamic tenant management.
+func (r *StaticTenantRegistry) Remove(_ context.Context, _ string) error {
+	return status.Error(codes.Unimplemented, "Remove not supported on StaticTenantRegistry — use MultiTenantRegistry")
 }
 
 // Get returns the tokens.Manager for the given tenantID.

--- a/internal/testutil/mock_tenant_registry.go
+++ b/internal/testutil/mock_tenant_registry.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	tokens "github.com/aetomala/jwtauth/pkg/tokens"
+	registry "github.com/aetomala/token-engine/internal/registry"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,6 +42,34 @@ func (m *MockTenantRegistry) EXPECT() *MockTenantRegistryMockRecorder {
 	return m.recorder
 }
 
+// Add mocks base method.
+func (m *MockTenantRegistry) Add(ctx context.Context, tenantID string, cfg registry.TenantConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Add", ctx, tenantID, cfg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Add indicates an expected call of Add.
+func (mr *MockTenantRegistryMockRecorder) Add(ctx, tenantID, cfg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockTenantRegistry)(nil).Add), ctx, tenantID, cfg)
+}
+
+// Drain mocks base method.
+func (m *MockTenantRegistry) Drain(ctx context.Context, tenantID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Drain", ctx, tenantID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Drain indicates an expected call of Drain.
+func (mr *MockTenantRegistryMockRecorder) Drain(ctx, tenantID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Drain", reflect.TypeOf((*MockTenantRegistry)(nil).Drain), ctx, tenantID)
+}
+
 // Get mocks base method.
 func (m *MockTenantRegistry) Get(ctx context.Context, tenantID string) (tokens.TokenManager, error) {
 	m.ctrl.T.Helper()
@@ -54,4 +83,18 @@ func (m *MockTenantRegistry) Get(ctx context.Context, tenantID string) (tokens.T
 func (mr *MockTenantRegistryMockRecorder) Get(ctx, tenantID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTenantRegistry)(nil).Get), ctx, tenantID)
+}
+
+// Remove mocks base method.
+func (m *MockTenantRegistry) Remove(ctx context.Context, tenantID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Remove", ctx, tenantID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Remove indicates an expected call of Remove.
+func (mr *MockTenantRegistryMockRecorder) Remove(ctx, tenantID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockTenantRegistry)(nil).Remove), ctx, tenantID)
 }


### PR DESCRIPTION
## Summary

- Extends `TenantRegistry` interface with `Add(ctx, tenantID, TenantConfig)`, `Drain(ctx, tenantID)`, `Remove(ctx, tenantID)`
- Adds `TenantConfig` struct (`Issuer`, `Audience`)
- Adds `Unimplemented` stubs to `StaticTenantRegistry` + compile-time assertion
- Regenerates `mock_tenant_registry.go` with new interface methods
- Creates `MultiTenantRegistry`: per-tenant Redis key+token stack; `Namespace: tenantID` in Prometheus config to prevent duplicate-registration panics; snapshot `AllKeyManagers()`
- `Remove` enforces drain precondition (`codes.FailedPrecondition` if not draining first)

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — clean
- [x] `go test ./internal/registry/... -v -timeout 2m` — 40/40 specs pass
- [x] Coverage: 87.2% (floor: 85%)