### PR TITLE
feat(v0.5): promote CallerRegistry, MTLSAuthenticator, and RevokeAllForUserAndAudience handler

### DIFF
--- a/cmd/token-engine/main.go
+++ b/cmd/token-engine/main.go
@@ -121,7 +121,7 @@ func main() {
 	idempStore := store.NewRedisIdempotencyStore(redisClient, cfg.IdempotencyTTL)
 
 	// ===== Registries =====
-	callerReg := registry.NewStaticCallerRegistry(logger)
+	callerReg := registry.NewStaticCallerRegistry(&registry.CallerRegistryConfig{Version: 1}, logger)
 
 	// ===== Audit and Reconciliation =====
 	auditStore := audit.NewSlogAuditStore(logger)

--- a/go.mod
+++ b/go.mod
@@ -52,4 +52,5 @@ require (
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/integration/token_engine_test.go
+++ b/integration/token_engine_test.go
@@ -75,7 +75,14 @@ var _ = BeforeSuite(func() {
 
 	// ===== Interceptors (same order as main.go, otelgrpc skipped — noop OTel not needed) =====
 	auth := interceptor.NewStaticKeyAuthenticator(cfg.StaticCallerKeys)
-	callerReg := registry.NewStaticCallerRegistry(logger)
+	callerReg := registry.NewStaticCallerRegistry(&registry.CallerRegistryConfig{
+		Version: 1,
+		Callers: []registry.CallerEntry{
+			// test-caller is permitted for test-issuer (normal flow) and unknown-tenant
+			// (so the "unknown tenant" integration test reaches the registry and gets NotFound).
+			{Identity: "test-caller", PermittedTenants: []string{"test-issuer", "unknown-tenant"}},
+		},
+	}, logger)
 
 	correlationInterceptor := observability.NewCorrelationInterceptor(logger, metrics)
 	authInterceptor := interceptor.NewAuthInterceptor(auth, logger)

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -887,6 +887,105 @@ Describe("Phase 3: RevokeAllUserTokens", func() {
 		})
 	})
 })
+// ===== PHASE 3: RevokeAllForUserAndAudience =====
+Describe("Phase 3: RevokeAllForUserAndAudience handler", func() {
+	var (
+		ctx            context.Context
+		cancel         context.CancelFunc
+		ctrl           *gomock.Controller
+		mockReg        *testutil.MockTenantRegistry
+		mockAuditStore *testutil.MockStore
+		mockTM         *testutil.MockTokenManager
+		h              *handler.TokenHandler
+		req            *tokenv1.RevokeUserAndAudienceRequest
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		ctrl = gomock.NewController(GinkgoT())
+		mockReg = testutil.NewMockTenantRegistry(ctrl)
+		mockAuditStore = testutil.NewMockStore(ctrl)
+		mockTM = testutil.NewMockTokenManager(ctrl)
+		h = handler.NewTokenHandler(mockReg, mockAuditStore, obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
+		req = &tokenv1.RevokeUserAndAudienceRequest{TenantId: "tenant-1", UserId: "user-1", Audience: "api"}
+	})
+
+	AfterEach(func() {
+		cancel()
+		ctrl.Finish()
+	})
+
+	Context("when audit store is available and revocation succeeds", func() {
+		It("calls manager.RevokeAllForUserAndAudience with userId and audience", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), req.UserId, req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+
+			_, err := h.RevokeAllForUserAndAudience(ctx, req)
+			Expect(err).To(BeNil())
+		})
+
+		It("writes an audit log entry", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), req.UserId, req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Cond(func(v interface{}) bool {
+				e, ok := v.(audit.RevocationEvent)
+				return ok && e.Scope == audit.RevocationScopeUser && e.Target == req.UserId
+			})).Return(nil)
+
+			_, err := h.RevokeAllForUserAndAudience(ctx, req)
+			Expect(err).To(BeNil())
+		})
+
+		It("returns RevokeTokenResponse{} and nil error", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), req.UserId, req.Audience).Return(nil)
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Return(nil)
+
+			resp, err := h.RevokeAllForUserAndAudience(ctx, req)
+			Expect(err).To(BeNil())
+			Expect(resp).To(Equal(&tokenv1.RevokeTokenResponse{}))
+		})
+	})
+
+	Context("when audit store is unavailable", func() {
+		It("returns codes.Unavailable without calling the Manager", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(errors.New("store unavailable"))
+			mockTM.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+			resp, err := h.RevokeAllForUserAndAudience(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.Unavailable))
+		})
+	})
+
+	Context("when manager.RevokeAllForUserAndAudience returns an error", func() {
+		It("returns a mapped gRPC status error", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(mockTM, nil)
+			mockTM.EXPECT().RevokeAllForUserAndAudience(gomock.Any(), req.UserId, req.Audience).Return(errors.New("revoke failed"))
+			mockAuditStore.EXPECT().RecordRevocation(gomock.Any(), gomock.Any()).Times(0)
+
+			resp, err := h.RevokeAllForUserAndAudience(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Context("when tenantID is unknown", func() {
+		It("returns codes.NotFound", func() {
+			mockAuditStore.EXPECT().Ping(gomock.Any()).Return(nil)
+			mockReg.EXPECT().Get(gomock.Any(), req.TenantId).Return(nil, status.Error(codes.NotFound, "tenant not found"))
+
+			resp, err := h.RevokeAllForUserAndAudience(ctx, req)
+			Expect(resp).To(BeNil())
+			Expect(status.Code(err)).To(Equal(codes.NotFound))
+		})
+	})
+})
 }) // TokenHandler
 
 var _ = Describe("JWKSHandler", func() {

--- a/internal/handler/token.go
+++ b/internal/handler/token.go
@@ -20,9 +20,10 @@ import (
 // This guard applies to: RevokeToken, RevokeAllForAudience, RevokeAllUserTokens.
 
 const (
-	spanNameRevokeToken          = "RevokeToken"
-	spanNameRevokeAllForAudience = "RevokeAllForAudience"
-	spanNameRevokeAllUserTokens  = "RevokeAllUserTokens"
+	spanNameRevokeToken                    = "RevokeToken"
+	spanNameRevokeAllForAudience           = "RevokeAllForAudience"
+	spanNameRevokeAllUserTokens            = "RevokeAllUserTokens"
+	spanNameRevokeAllForUserAndAudience    = "RevokeAllForUserAndAudience"
 )
 
 // TokenHandler implements the TokenEngine gRPC service.
@@ -298,6 +299,54 @@ func (h *TokenHandler) RevokeAllUserTokens(ctx context.Context, req *tokenv1.Rev
 		return nil, status.Error(codes.Internal, "audit record failed")
 	}
 
+	span.SetStatus(observability.StatusOK, "")
+	return &tokenv1.RevokeTokenResponse{}, nil
+}
+
+// RevokeAllForUserAndAudience revokes all tokens for the given user and audience combination.
+// Gated on audit store availability — returns codes.Unavailable if audit store is unreachable.
+func (h *TokenHandler) RevokeAllForUserAndAudience(ctx context.Context, req *tokenv1.RevokeUserAndAudienceRequest) (*tokenv1.RevokeTokenResponse, error) {
+	// ===== STEP 1: Audit gate =====
+	if err := h.auditStore.Ping(ctx); err != nil {
+		h.logger.Warn(ctx, "audit store unavailable", "error", err)
+		return nil, status.Error(codes.Unavailable, "audit store unavailable")
+	}
+
+	// ===== STEP 2: Open span =====
+	ctx, span := h.tracer.Start(ctx, spanNameRevokeAllForUserAndAudience)
+	defer span.End()
+
+	// ===== STEP 3: Resolve tenant =====
+	tenantID := req.TenantId
+	manager, err := h.registry.Get(ctx, tenantID)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(observability.StatusError, err.Error())
+		return nil, err
+	}
+
+	// ===== STEP 4: Revoke =====
+	if err := manager.RevokeAllForUserAndAudience(ctx, req.UserId, req.Audience); err != nil {
+		mapped := observability.MapLibraryError(err)
+		span.RecordError(mapped)
+		span.SetStatus(observability.StatusError, mapped.Error())
+		return nil, mapped
+	}
+
+	// ===== STEP 5: Record audit event =====
+	event := audit.RevocationEvent{
+		TenantID: tenantID,
+		Target:   req.UserId,
+		Scope:    audit.RevocationScopeUser,
+	}
+	if err := h.auditStore.RecordRevocation(ctx, event); err != nil {
+		h.logger.Error(ctx, "failed to record revocation audit", "error", err)
+		span.RecordError(err)
+		span.SetStatus(observability.StatusError, err.Error())
+		return nil, status.Error(codes.Internal, "audit record failed")
+	}
+
+	// ===== STEP 6: Success =====
 	span.SetStatus(observability.StatusOK, "")
 	return &tokenv1.RevokeTokenResponse{}, nil
 }

--- a/internal/interceptor/auth.go
+++ b/internal/interceptor/auth.go
@@ -6,7 +6,9 @@ import (
 	"github.com/aetomala/token-engine/internal/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -18,6 +20,44 @@ type Authenticator interface {
 	// Returns the caller identity string on success.
 	// Returns a gRPC status error directly — callers must not wrap the error.
 	Authenticate(ctx context.Context) (callerIdentity string, err error)
+}
+
+// ===== MTLSAuthenticator =====
+
+// MTLSAuthenticator authenticates requests using the TLS peer certificate Common Name.
+// The gRPC server is configured with tls.RequireAndVerifyClientCert — the certificate
+// has already been cryptographically verified before Authenticate is called.
+// MTLSAuthenticator only extracts identity; it does not perform certificate verification.
+// All methods are safe for concurrent use.
+type MTLSAuthenticator struct{}
+
+var _ Authenticator = (*MTLSAuthenticator)(nil)
+
+// NewMTLSAuthenticator returns a new MTLSAuthenticator.
+func NewMTLSAuthenticator() *MTLSAuthenticator {
+	return &MTLSAuthenticator{}
+}
+
+// Authenticate extracts the caller identity from the TLS peer certificate Common Name.
+// Returns codes.Unauthenticated if: no peer in context, peer has no TLS credentials,
+// peer has no certificates, or the leaf certificate has an empty Common Name.
+func (a *MTLSAuthenticator) Authenticate(ctx context.Context) (string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", status.Error(codes.Unauthenticated, "no peer information in context")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return "", status.Error(codes.Unauthenticated, "no TLS credentials in peer")
+	}
+	if len(tlsInfo.State.PeerCertificates) == 0 {
+		return "", status.Error(codes.Unauthenticated, "no client certificates provided")
+	}
+	cn := tlsInfo.State.PeerCertificates[0].Subject.CommonName
+	if cn == "" {
+		return "", status.Error(codes.Unauthenticated, "client certificate Common Name is empty")
+	}
+	return cn, nil
 }
 
 // ===== StaticKeyAuthenticator =====

--- a/internal/interceptor/caller.go
+++ b/internal/interceptor/caller.go
@@ -2,19 +2,59 @@ package interceptor
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aetomala/token-engine/internal/observability"
 	"github.com/aetomala/token-engine/internal/registry"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-// ===== NewCallerAuthorizationInterceptor =====
+// TenantAwareRequest is satisfied by all proto request messages containing a tenant_id field.
+// proto-gen-go generates GetTenantId() string for every proto3 message with a string tenant_id field.
+// Used by the caller interceptor to extract tenant_id without type-asserting each request type individually.
+type TenantAwareRequest interface {
+	GetTenantId() string
+}
+
+const (
+	grpcHealthPrefix = "/grpc.health.v1.Health/"
+)
 
 // NewCallerAuthorizationInterceptor returns a gRPC unary server interceptor for caller authorization.
-// v0.1–v0.4: stub — return handler(ctx, req). registry and logger accepted but unused.
-// v0.5: real implementation — registry lookup against caller identity and tenant_id.
+// Skips authorization for gRPC health protocol RPCs.
+// Returns codes.Internal if no caller identity is present in context (auth interceptor must run first).
+// Returns codes.PermissionDenied if the caller is not authorized for the requested tenant.
 func NewCallerAuthorizationInterceptor(reg registry.CallerRegistry, logger observability.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		// ===== STEP 1: Skip health protocol RPCs =====
+		if strings.HasPrefix(info.FullMethod, grpcHealthPrefix) {
+			return handler(ctx, req)
+		}
+
+		// ===== STEP 2: Extract caller identity =====
+		callerIdentity := observability.CallerIdentityFromContext(ctx)
+		if callerIdentity == "" {
+			return nil, status.Error(codes.Internal, "caller identity not set in context")
+		}
+
+		// ===== STEP 3: Extract tenantID =====
+		tenantID := ""
+		if tar, ok := req.(TenantAwareRequest); ok {
+			tenantID = tar.GetTenantId()
+		}
+
+		// ===== STEP 4: Check authorization =====
+		permitted, err := reg.IsPermitted(ctx, callerIdentity, tenantID)
+		if err != nil {
+			return nil, err
+		}
+		if !permitted {
+			return nil, status.Error(codes.PermissionDenied, "caller not authorized")
+		}
+
+		// ===== STEP 5: Call handler =====
 		return handler(ctx, req)
 	}
 }

--- a/internal/interceptor/interceptor_test.go
+++ b/internal/interceptor/interceptor_test.go
@@ -2,6 +2,9 @@ package interceptor_test
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"time"
 
@@ -14,10 +17,21 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
+
+// peerCtxWithCN builds a context containing a fake TLS peer with the given Common Name.
+func peerCtxWithCN(cn string) context.Context {
+	cert := &x509.Certificate{Subject: pkix.Name{CommonName: cn}}
+	tlsInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}},
+	}
+	return peer.NewContext(context.Background(), &peer.Peer{AuthInfo: tlsInfo})
+}
 
 var _ = Describe("AuthInterceptor", func() {
 	var (
@@ -762,14 +776,79 @@ var _ = Describe("ValidationInterceptor (v0.1 stub)", func() {
 	}) // Phase 3
 })
 
-var _ = Describe("CallerAuthorizationInterceptor (v0.1 stub)", func() {
+var _ = Describe("MTLSAuthenticator", func() {
+	var sut *interceptor.MTLSAuthenticator
+
+	BeforeEach(func() {
+		sut = interceptor.NewMTLSAuthenticator()
+	})
+
+	// ===== PHASE 3: Core Operations =====
+	Describe("Phase 3: Core Operations", func() {
+	Context("when peer has a valid TLS certificate with non-empty CN", func() {
+		It("returns the CN as caller identity", func() {
+			ctx := peerCtxWithCN("service-a")
+
+			identity, err := sut.Authenticate(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identity).To(Equal("service-a"))
+		})
+	})
+
+	Context("when no peer information in context", func() {
+		It("returns codes.Unauthenticated", func() {
+			_, err := sut.Authenticate(context.Background())
+
+			Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+		})
+	})
+
+	Context("when peer has no TLS credentials", func() {
+		It("returns codes.Unauthenticated", func() {
+			ctx := peer.NewContext(context.Background(), &peer.Peer{
+				AuthInfo: nil,
+			})
+
+			_, err := sut.Authenticate(ctx)
+
+			Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+		})
+	})
+
+	Context("when peer has no certificates", func() {
+		It("returns codes.Unauthenticated", func() {
+			tlsInfo := credentials.TLSInfo{
+				State: tls.ConnectionState{PeerCertificates: nil},
+			}
+			ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: tlsInfo})
+
+			_, err := sut.Authenticate(ctx)
+
+			Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+		})
+	})
+
+	Context("when leaf certificate has empty Common Name", func() {
+		It("returns codes.Unauthenticated", func() {
+			ctx := peerCtxWithCN("")
+
+			_, err := sut.Authenticate(ctx)
+
+			Expect(status.Code(err)).To(Equal(codes.Unauthenticated))
+		})
+	})
+	}) // Phase 3
+})
+
+var _ = Describe("CallerAuthorizationInterceptor", func() {
 	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-		ctrl   *gomock.Controller
+		ctx          context.Context
+		cancel       context.CancelFunc
+		ctrl         *gomock.Controller
 		mockRegistry *testutil.MockCallerRegistry
-		mockLogger *testutil.MockLogger
-		sut grpc.UnaryServerInterceptor
+		mockLogger   *testutil.MockLogger
+		sut          grpc.UnaryServerInterceptor
 	)
 
 	BeforeEach(func() {
@@ -787,19 +866,97 @@ var _ = Describe("CallerAuthorizationInterceptor (v0.1 stub)", func() {
 
 	// ===== PHASE 3: Core Operations =====
 	Describe("Phase 3: Core Operations", func() {
-	Context("always", func() {
-		It("calls the handler and returns its result unchanged", func() {
-			expectedResp := "authorized"
-			expectedErr := errors.New("authorization error")
-
+	Context("when method is gRPC health protocol", func() {
+		It("calls the handler without checking the registry", func() {
+			mockRegistry.EXPECT().IsPermitted(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			handlerCalled := false
 			handler := func(ctxIn context.Context, req interface{}) (interface{}, error) {
-				return expectedResp, expectedErr
+				handlerCalled = true
+				return "ok", nil
 			}
 
-			resp, err := sut(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+			_, _ = sut(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}, handler)
 
-			Expect(resp).To(Equal(expectedResp))
-			Expect(err).To(Equal(expectedErr))
+			Expect(handlerCalled).To(BeTrue())
+		})
+	})
+
+	Context("when caller identity is empty in context", func() {
+		It("returns codes.Internal without calling the registry", func() {
+			mockRegistry.EXPECT().IsPermitted(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+			_, err := sut(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/IssueToken"}, nil)
+
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+		})
+	})
+
+	Context("when caller is permitted for the tenant", func() {
+		BeforeEach(func() {
+			ctx = observability.WithCallerIdentity(ctx, "service-a")
+		})
+
+		It("calls the handler", func() {
+			mockRegistry.EXPECT().IsPermitted(gomock.Any(), "service-a", gomock.Any()).Return(true, nil)
+			handlerCalled := false
+			handler := func(ctxIn context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return "resp", nil
+			}
+
+			_, _ = sut(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/IssueToken"}, handler)
+
+			Expect(handlerCalled).To(BeTrue())
+		})
+
+		It("returns the handler's response", func() {
+			mockRegistry.EXPECT().IsPermitted(gomock.Any(), "service-a", gomock.Any()).Return(true, nil)
+			expected := "the-response"
+			handler := func(ctxIn context.Context, req interface{}) (interface{}, error) {
+				return expected, nil
+			}
+
+			resp, err := sut(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/IssueToken"}, handler)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(Equal(expected))
+		})
+	})
+
+	Context("when IsPermitted returns codes.PermissionDenied", func() {
+		BeforeEach(func() {
+			ctx = observability.WithCallerIdentity(ctx, "service-b")
+		})
+
+		It("returns the error without calling the handler", func() {
+			permErr := status.Error(codes.PermissionDenied, "caller not authorized")
+			mockRegistry.EXPECT().IsPermitted(gomock.Any(), "service-b", gomock.Any()).Return(false, permErr)
+			handlerCalled := false
+			handler := func(ctxIn context.Context, req interface{}) (interface{}, error) {
+				handlerCalled = true
+				return nil, nil
+			}
+
+			_, err := sut(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/IssueToken"}, handler)
+
+			Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+			Expect(handlerCalled).To(BeFalse())
+		})
+	})
+
+	Context("when req does not implement TenantAwareRequest", func() {
+		BeforeEach(func() {
+			ctx = observability.WithCallerIdentity(ctx, "service-a")
+		})
+
+		It("passes tenantID as empty string to IsPermitted", func() {
+			mockRegistry.EXPECT().IsPermitted(gomock.Any(), "service-a", "").Return(true, nil)
+			handler := func(ctxIn context.Context, req interface{}) (interface{}, error) {
+				return "ok", nil
+			}
+
+			// Pass a non-TenantAwareRequest value (plain string, not a proto message)
+			_, _ = sut(ctx, "not-a-tenant-aware-req", &grpc.UnaryServerInfo{FullMethod: "/token.v1.TokenEngine/IssueToken"}, handler)
 		})
 	})
 	}) // Phase 3

--- a/internal/registry/caller.go
+++ b/internal/registry/caller.go
@@ -2,6 +2,11 @@ package registry
 
 import (
 	"context"
+	"os"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 
 	"github.com/aetomala/token-engine/internal/observability"
 )
@@ -9,26 +14,83 @@ import (
 // CallerRegistry provides caller authorization checks for tenant operations.
 type CallerRegistry interface {
 	// IsPermitted returns true if the given callerIdentity is authorized to operate on tenantID.
-	// v0.1 stub: return true, nil for all inputs — all callers permitted.
-	// v0.5: return false, codes.PermissionDenied if not in permitted_tenants list.
+	// Returns (false, codes.PermissionDenied) if the caller is not authorized.
 	IsPermitted(ctx context.Context, callerIdentity string, tenantID string) (bool, error)
 }
 
-// StaticCallerRegistry is a v0.1 stub implementation of CallerRegistry.
-// All callers are permitted in v0.1.
-type StaticCallerRegistry struct {
-	logger observability.Logger
+// CallerRegistryConfig is the decoded contents of the caller-registry YAML file.
+type CallerRegistryConfig struct {
+	Version int           `yaml:"version"`
+	Callers []CallerEntry `yaml:"callers"`
 }
 
-// NewStaticCallerRegistry returns a new StaticCallerRegistry.
-// logger is accepted but unused in v0.1.
-func NewStaticCallerRegistry(logger observability.Logger) *StaticCallerRegistry {
+// CallerEntry is a single caller in the registry config.
+type CallerEntry struct {
+	Identity         string   `yaml:"identity"`
+	PermittedTenants []string `yaml:"permitted_tenants"`
+}
+
+// LoadCallerRegistryConfig opens and decodes a caller-registry YAML file.
+// Returns error if the file cannot be opened or YAML is malformed.
+// Does NOT validate the decoded config — callers must validate separately.
+func LoadCallerRegistryConfig(path string) (*CallerRegistryConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var cfg CallerRegistryConfig
+	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// StaticCallerRegistry is an in-memory implementation of CallerRegistry backed by a
+// YAML-decoded CallerRegistryConfig. It checks each request against a pre-built
+// allowed map of identity → set of permitted tenants.
+// All methods are safe for concurrent use — the allowed map is read-only after construction.
+type StaticCallerRegistry struct {
+	allowed map[string]map[string]bool // identity → set of permitted tenants
+	logger  observability.Logger
+}
+
+var _ CallerRegistry = (*StaticCallerRegistry)(nil)
+
+// NewStaticCallerRegistry constructs a StaticCallerRegistry from an already-loaded config.
+// cfg must not be nil. cfg must have been validated before this call.
+// logger is used for authorization decision logging.
+func NewStaticCallerRegistry(cfg *CallerRegistryConfig, logger observability.Logger) *StaticCallerRegistry {
+	allowed := make(map[string]map[string]bool, len(cfg.Callers))
+	for _, entry := range cfg.Callers {
+		tenantSet := make(map[string]bool, len(entry.PermittedTenants))
+		for _, t := range entry.PermittedTenants {
+			tenantSet[t] = true
+		}
+		allowed[entry.Identity] = tenantSet
+	}
 	return &StaticCallerRegistry{
-		logger: logger,
+		allowed: allowed,
+		logger:  logger,
 	}
 }
 
-// IsPermitted returns true for all inputs in v0.1 — all callers are permitted.
-func (r *StaticCallerRegistry) IsPermitted(ctx context.Context, callerIdentity string, tenantID string) (bool, error) {
+// IsPermitted returns true if callerIdentity is authorized to operate on tenantID.
+// If tenantID is empty, returns (true, nil) — validation interceptor handles the required check.
+// Returns (false, codes.PermissionDenied) if callerIdentity is not in the registry or tenantID
+// is not in the caller's permitted_tenants list.
+func (r *StaticCallerRegistry) IsPermitted(_ context.Context, callerIdentity string, tenantID string) (bool, error) {
+	if tenantID == "" {
+		return true, nil
+	}
+
+	tenantSet, found := r.allowed[callerIdentity]
+	if !found {
+		return false, status.Error(codes.PermissionDenied, "caller not authorized")
+	}
+	if !tenantSet[tenantID] {
+		return false, status.Error(codes.PermissionDenied, "caller not authorized")
+	}
 	return true, nil
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -2,53 +2,137 @@ package registry_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
+	"github.com/aetomala/token-engine/internal/observability"
 	"github.com/aetomala/token-engine/internal/registry"
-	"github.com/aetomala/token-engine/internal/testutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // StaticTenantRegistry tests are in PHASE-9C (require miniredis for real Redis-backed construction).
 
 var _ = Describe("StaticCallerRegistry", func() {
 	var (
-		ctx  context.Context
-		ctrl *gomock.Controller
+		ctx    context.Context
+		logger observability.Logger
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
+		logger = observability.NewNoOpLogger()
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
+	// ===== PHASE 3: Core Operations — IsPermitted =====
+	Describe("Phase 3: Core Operations — IsPermitted", func() {
+		Context("when callerIdentity is in registry and tenantID is permitted", func() {
+			It("returns (true, nil)", func() {
+				cfg := &registry.CallerRegistryConfig{
+					Version: 1,
+					Callers: []registry.CallerEntry{
+						{Identity: "caller-1", PermittedTenants: []string{"tenant-a", "tenant-b"}},
+					},
+				}
+				sut := registry.NewStaticCallerRegistry(cfg, logger)
 
-	// ===== PHASE 3: Core Operations =====
-	Describe("Phase 3: Core Operations", func() {
-	Context("IsPermitted", func() {
-		It("returns true for all inputs in v0.1 stub", func() {
-			mockLogger := testutil.NewMockLogger(ctrl)
-			sut := registry.NewStaticCallerRegistry(mockLogger)
+				permitted, err := sut.IsPermitted(ctx, "caller-1", "tenant-a")
 
-			permitted, err := sut.IsPermitted(ctx, "caller-1", "tenant-1")
-
-			Expect(err).To(BeNil())
-			Expect(permitted).To(BeTrue())
+				Expect(err).To(BeNil())
+				Expect(permitted).To(BeTrue())
+			})
 		})
 
-		It("returns true for blank inputs in v0.1 stub", func() {
-			mockLogger := testutil.NewMockLogger(ctrl)
-			sut := registry.NewStaticCallerRegistry(mockLogger)
+		Context("when callerIdentity is in registry but tenantID is not in permitted_tenants", func() {
+			It("returns (false, codes.PermissionDenied error)", func() {
+				cfg := &registry.CallerRegistryConfig{
+					Version: 1,
+					Callers: []registry.CallerEntry{
+						{Identity: "caller-1", PermittedTenants: []string{"tenant-a"}},
+					},
+				}
+				sut := registry.NewStaticCallerRegistry(cfg, logger)
 
-			permitted, err := sut.IsPermitted(ctx, "", "")
+				permitted, err := sut.IsPermitted(ctx, "caller-1", "tenant-z")
 
-			Expect(err).To(BeNil())
-			Expect(permitted).To(BeTrue())
+				Expect(permitted).To(BeFalse())
+				Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+			})
+		})
+
+		Context("when callerIdentity is not in registry", func() {
+			It("returns (false, codes.PermissionDenied error)", func() {
+				cfg := &registry.CallerRegistryConfig{Version: 1, Callers: []registry.CallerEntry{}}
+				sut := registry.NewStaticCallerRegistry(cfg, logger)
+
+				permitted, err := sut.IsPermitted(ctx, "unknown-caller", "tenant-a")
+
+				Expect(permitted).To(BeFalse())
+				Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+			})
+		})
+
+		Context("when tenantID is empty", func() {
+			It("returns (true, nil) without checking permitted_tenants", func() {
+				cfg := &registry.CallerRegistryConfig{Version: 1, Callers: []registry.CallerEntry{}}
+				sut := registry.NewStaticCallerRegistry(cfg, logger)
+
+				permitted, err := sut.IsPermitted(ctx, "any-caller", "")
+
+				Expect(err).To(BeNil())
+				Expect(permitted).To(BeTrue())
+			})
 		})
 	})
-	}) // Phase 3
+
+	// ===== PHASE 3: Core Operations — LoadCallerRegistryConfig =====
+	Describe("Phase 3: Core Operations — LoadCallerRegistryConfig", func() {
+		Context("when file exists and is valid YAML", func() {
+			It("decodes version, callers, identities, and permitted_tenants", func() {
+				dir := GinkgoT().TempDir()
+				path := filepath.Join(dir, "callers.yaml")
+				content := `version: 1
+callers:
+  - identity: service-a
+    permitted_tenants:
+      - tenant-1
+      - tenant-2
+  - identity: service-b
+    permitted_tenants:
+      - tenant-3
+`
+				Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+
+				cfg, err := registry.LoadCallerRegistryConfig(path)
+
+				Expect(err).To(BeNil())
+				Expect(cfg.Version).To(Equal(1))
+				Expect(cfg.Callers).To(HaveLen(2))
+				Expect(cfg.Callers[0].Identity).To(Equal("service-a"))
+				Expect(cfg.Callers[0].PermittedTenants).To(ConsistOf("tenant-1", "tenant-2"))
+				Expect(cfg.Callers[1].Identity).To(Equal("service-b"))
+				Expect(cfg.Callers[1].PermittedTenants).To(ConsistOf("tenant-3"))
+			})
+		})
+
+		Context("when file does not exist", func() {
+			It("returns an error", func() {
+				_, err := registry.LoadCallerRegistryConfig("/nonexistent/path/callers.yaml")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when file contains invalid YAML", func() {
+			It("returns an error", func() {
+				dir := GinkgoT().TempDir()
+				path := filepath.Join(dir, "bad.yaml")
+				Expect(os.WriteFile(path, []byte(":\t invalid yaml\n"), 0600)).To(Succeed())
+
+				_, err := registry.LoadCallerRegistryConfig(path)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- **PHASE-4**: Replace stub `StaticCallerRegistry` with real YAML-backed implementation; add `CallerRegistryConfig`, `CallerEntry`, `LoadCallerRegistryConfig`; real `IsPermitted` with per-caller tenant sets; add `gopkg.in/yaml.v3 v3.0.1`
- **PHASE-5**: Promote `CallerAuthorizationInterceptor` from stub to real (health skip, identity guard, `TenantAwareRequest` extraction); add `MTLSAuthenticator` that extracts caller identity from verified TLS peer certificate CN
- **PHASE-6**: Add `RevokeAllForUserAndAudience` handler to `TokenHandler` — audit gate, span lifecycle, `manager.RevokeAllForUserAndAudience`, audit record

## Corrections Applied

- Integration test `CallerRegistryConfig` updated to grant `test-caller` permission for `test-issuer` and `unknown-tenant` after real interceptor promotion caused 9 failures
- `cmd/token-engine/main.go` updated to new `NewStaticCallerRegistry(*CallerRegistryConfig, Logger)` signature (PHASE-4 packet listed only 3 files but this was a necessary compile fix)

## Test Plan

- [x] `go build ./...` — passes (no output)
- [x] `go vet ./...` — passes (silence)
- [x] `go test ./internal/registry/... -timeout 2m` — 45/45 pass
- [x] `go test ./internal/interceptor/... -v` — 70/70 pass
- [x] `go test ./internal/handler/...` — 64/64 pass
- [x] `go test ./internal/... -timeout 2m` — all packages green
- [x] `go test ./integration/... -timeout 2m` — 11/11 pass