### PR TITLE
docs: sync human-readable docs with v0.5 completion and roadmap rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added (v0.5.0)
+
+- `RevokeAllForUserAndAudience` RPC — revokes all refresh tokens for a user within a specific
+  audience; audit-gated (returns `codes.Unavailable` if audit store unreachable)
+- `MTLSAuthenticator` — extracts caller identity from TLS peer certificate Common Name;
+  selected when `TOKEN_ENGINE_TLS_MODE=mtls`
+- mTLS gRPC server credentials — loads cert/key/CA from filesystem; enforces
+  `RequireAndVerifyClientCert` with TLS 1.3 minimum; wired in `main.go`
+- Static YAML caller registry — `CallerRegistryConfig` / `LoadCallerRegistryConfig` decode
+  `caller-registry.yaml`; `StaticCallerRegistry.IsPermitted` promoted from stub to real
+  implementation; `TOKEN_ENGINE_CALLER_REGISTRY_PATH` config field
+- `MultiTenantRegistry` — replaces `StaticTenantRegistry`; supports dynamic `Add`/`Drain`/`Remove`
+  with per-tenant `KeyManager` + `RefreshStore` namespace isolation
+- `deploy/caller-registry.yaml` — example caller authorization config with format documentation
+- Integration test suite extended to 12 specs — added `RevokeAllForUserAndAudience` end-to-end
+  test covering revoke → subsequent refresh fails
+
+### Changed
+
+- `StaticTenantRegistry` removed — `MultiTenantRegistry` is now the sole `TenantRegistry`
+  implementation; `main.go` wires `Add` on startup, iterates `AllKeyManagers()` for health
+  checkers, JWKS handler, and graceful shutdown
+- Authenticator selection is now conditional on `TOKEN_ENGINE_TLS_MODE` — `MTLSAuthenticator`
+  for `mtls`, `StaticKeyAuthenticator` for `disabled`
+
+### Version Deferrals (v0.6)
+
+- Token reconciliation — `NoOpReconciler` remains; cursor-based implementation deferred to v0.6
+- `RefreshToken` idempotency — deferred to v0.6 (requires refresh token rotation + idempotency
+  store interaction to be safe)
+- Distributed locks — deferred to v0.6 (single-replica deployment required until then)
+- Kubernetes manifests — deferred to v0.6
+
 ---
 
 ## [v0.4.0] — 2026-05-29

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ A production-grade gRPC service that wraps [jwtauth](https://github.com/aetomala
 | `RevokeToken` | Revoke a single refresh token immediately |
 | `RevokeAllForAudience` | Revoke all tokens scoped to an audience |
 | `RevokeAllUserTokens` | Revoke all tokens for a user across all audiences |
+| `RevokeAllForUserAndAudience` | Revoke all tokens for a user within a specific audience |
 
 **Interceptor chain (applied to every RPC):**
-OpenTelemetry tracing → Correlation ID → API key authentication → Caller authorization → Idempotency → Request validation
+OpenTelemetry tracing → Correlation ID → Authentication (API key or mTLS CN) → Caller authorization → Idempotency → Request validation
 
 **Observability:** Prometheus metrics at `/metrics`, OpenTelemetry traces via OTLP, structured slog logging with correlation IDs, health probes at `/healthz/live` and `/healthz/ready`.
 
@@ -65,6 +66,10 @@ All configuration is via environment variables. The service exits fatally at sta
 | `TOKEN_ENGINE_AUDIENCE` | string | **required** | fatal exit |
 | `TOKEN_ENGINE_TLS_MODE` | `mtls` \| `disabled` | `mtls` | fatal exit |
 | `TOKEN_ENGINE_STATIC_CALLER_KEYS` | `key=id,key=id` | required when TLS disabled | fatal exit |
+| `TOKEN_ENGINE_TLS_CERT_FILE` | string | `` | required when `TLS_MODE=mtls` |
+| `TOKEN_ENGINE_TLS_KEY_FILE` | string | `` | required when `TLS_MODE=mtls` |
+| `TOKEN_ENGINE_TLS_CA_FILE` | string | `` | required when `TLS_MODE=mtls` |
+| `TOKEN_ENGINE_CALLER_REGISTRY_PATH` | string | `` | optional; path to `caller-registry.yaml` |
 | `TOKEN_ENGINE_GRPC_ADDR` | string | `:9090` | warning + default |
 | `TOKEN_ENGINE_HTTP_ADDR` | string | `:8080` | warning + default |
 | `TOKEN_ENGINE_IDEMPOTENCY_TTL` | duration | `24h` | warning + default |
@@ -136,6 +141,16 @@ Revokes all refresh tokens for a user across all audiences within a tenant.
 | Field | Type | Description |
 |---|---|---|
 | `user_id` | string | User whose tokens are revoked (required) |
+| `tenant_id` | string | Tenant scope (required) |
+
+### RevokeAllForUserAndAudience
+
+Revokes all refresh tokens for a user within a specific audience.
+
+| Field | Type | Description |
+|---|---|---|
+| `user_id` | string | User whose tokens are revoked (required) |
+| `audience` | string | Audience scope (required) |
 | `tenant_id` | string | Tenant scope (required) |
 
 ### Error Codes
@@ -252,8 +267,8 @@ Architecture decisions are recorded in [doc/adr/](doc/adr/).
 | v0.2 | ✅ Complete | Single hardcoded tenant, Redis key + refresh stores, `IssueToken` + `RefreshToken` live |
 | v0.3 | ✅ Complete | `RevokeToken`, `RevokeAllForAudience`, `RevokeAllUserTokens`, JWKS endpoint, `SlogAuditStore`, CD pipeline |
 | v0.4 | ✅ Complete | `RedisIdempotencyStore` + full idempotency interceptor, 24h TTL default, shutdown hardening, end-to-end integration test suite |
-| v0.5 | Planned | mTLS authenticator, static YAML caller registry, full multi-tenant `TenantRegistry` |
-| v1.0 | Planned | Distributed locks, cursor-based reconciler, Kubernetes manifests, operator runbook |
+| v0.5 | ✅ Complete | `RevokeAllForUserAndAudience` RPC; `MTLSAuthenticator`; static YAML caller registry; `MultiTenantRegistry` with `Add`/`Drain`/`Remove`; mTLS gRPC server credentials (TLS 1.3 min) |
+| v0.6 | Planned | Distributed locks, cursor-based reconciler, Kubernetes manifests, `RefreshToken` idempotency, operator runbook |
 
 ---
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -19,10 +19,10 @@ cmd/token-engine/main.go
 │   ├── Logger        (internal/observability — SlogLogger)
 │   ├── Metrics       (internal/observability — PrometheusMetrics)
 │   └── Tracer        (internal/observability — OtelTracer)
-├── Authenticator     (internal/interceptor — StaticKeyAuthenticator)
+├── Authenticator     (internal/interceptor — MTLSAuthenticator [mtls] / StaticKeyAuthenticator [disabled])
 ├── Registries
-│   ├── CallerRegistry  (internal/registry — StaticCallerRegistry)
-│   └── TenantRegistry  (internal/registry — StaticTenantRegistry)
+│   ├── CallerRegistry  (internal/registry — StaticCallerRegistry, YAML-backed, v0.5)
+│   └── TenantRegistry  (internal/registry — MultiTenantRegistry, v0.5)
 ├── Stores
 │   └── IdempotencyStore (internal/store — RedisIdempotencyStore, v0.4)
 ├── Audit             (internal/audit — SlogAuditStore, v0.3)
@@ -79,7 +79,7 @@ OTel interceptor        — extracts/creates trace context; starts server span
 Correlation interceptor — generates UUID; stores in context; logs to all downstream log lines
   │
   ▼
-Auth interceptor        — reads Authorization header; looks up API key in StaticKeyAuthenticator
+Auth interceptor        — reads TLS peer CN [mtls] or x-api-key header [disabled]; sets caller identity in context
   │  ← UNAUTHENTICATED if key missing or unrecognized
   ▼
 CallerAuthz interceptor — checks caller identity against tenant's allowed callers list
@@ -151,10 +151,10 @@ Components with interface seams produce correct behavior (no panics, no errors) 
 | Component | Interface | Current Implementation | Status |
 |---|---|---|---|
 | Audit logging | `audit.AuditStore` | `SlogAuditStore` (structured log sink) | Live — v0.3 |
-| Token reconciliation | `reconciliation.TokenReconciler` | `NoOpReconciler` | Deferred — v0.5+ |
-| Dynamic tenant registry | `registry.TenantRegistry` | `StaticTenantRegistry` (static config, real `tokens.TokenManager`) | Static — Redis backend deferred to v0.5 |
+| Token reconciliation | `reconciliation.TokenReconciler` | `NoOpReconciler` | Deferred — v0.6 |
+| Dynamic tenant registry | `registry.TenantRegistry` | `MultiTenantRegistry` | Live — v0.5 |
 | Idempotency store | `store.IdempotencyStore` | `RedisIdempotencyStore` (24h TTL default) | Live — v0.4 |
-| Caller registry | `registry.CallerRegistry` | `StaticCallerRegistry` | Deferred — v1.0 |
+| Caller registry | `registry.CallerRegistry` | `StaticCallerRegistry` (YAML-backed) | Live — v0.5 |
 
 ---
 
@@ -203,8 +203,8 @@ Mocks are generated with `go.uber.org/mock/mockgen` in source mode. All mocks li
 | v0.2 | ✅ Complete | Single hardcoded tenant, Redis key + refresh stores, `tokens.Manager` wired, `IssueToken` + `RefreshToken` live |
 | v0.3 | ✅ Complete | `RevokeToken`, `RevokeAllForAudience`, `RevokeAllUserTokens` handlers, JWKS endpoint, `SlogAuditStore`, jwtauth v0.7.1 (`tokens.TokenManager` interface) |
 | v0.4 | ✅ Complete | `RedisIdempotencyStore` + full idempotency interceptor (promoted from NoOp), 24h TTL default, shutdown hardening (OTel flush, gRPC 10s drain, HTTP timeouts), end-to-end integration test suite |
-| v0.5 | Planned | mTLS authenticator, static YAML caller registry, full multi-tenant `TenantRegistry` with drain/remove lifecycle |
-| v1.0 | Planned | Distributed locks for key rotation + reconciliation, cursor-based reconciler, Kubernetes manifests, operator runbook |
+| v0.5 | ✅ Complete | `RevokeAllForUserAndAudience` RPC + handler; `MTLSAuthenticator`; static YAML caller registry (`CallerRegistryConfig`, `LoadCallerRegistryConfig`); `MultiTenantRegistry` with `Add`/`Drain`/`Remove` + per-tenant namespace isolation; mTLS gRPC server credentials (TLS 1.3 min); `deploy/caller-registry.yaml`; integration suite at 12 specs |
+| v0.6 | Planned | Per-operation distributed locks (key rotation + reconciliation); cursor-based `Reconciler` replacing `NoOpReconciler` (ADR-011); JWKS key count metric; `RefreshToken` idempotency promoted; Kubernetes manifests + startup probe co-designed with key rotation interval; `govulncheck` + `golangci-lint` with `revive`/`godot` enforced in CI; operator runbook |
 
 ---
 
@@ -218,3 +218,4 @@ Mocks are generated with `go.uber.org/mock/mockgen` in source mode. All mocks li
 | [ADR-004](adr/ADR-004-noop-stubs-v01.md) | NoOp stubs for audit, reconciliation, and tenant registry in v0.1 |
 | [ADR-005](adr/ADR-005-in-memory-idempotency-v01.md) | In-memory idempotency store for v0.1 |
 | [ADR-006](adr/ADR-006-interceptor-chain-order.md) | Interceptor chain ordering rationale |
+| [ADR-011](adr/ADR-011-cursor-based-reconciler.md) | Cursor-Based Reconciler | Planned — v0.6 |

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -8,7 +8,8 @@ Before starting the service:
 - [ ] `TOKEN_ENGINE_AUDIENCE` set — non-empty string
 - [ ] `TOKEN_ENGINE_TLS_MODE` set — `mtls` or `disabled`
 - [ ] If `TLS_MODE=disabled`: `TOKEN_ENGINE_STATIC_CALLER_KEYS` set with at least one entry
-- [ ] If `TLS_MODE=mtls`: TLS certificates provisioned and accessible to the process
+- [ ] If `TLS_MODE=mtls`: `TOKEN_ENGINE_TLS_CERT_FILE`, `TOKEN_ENGINE_TLS_KEY_FILE`, `TOKEN_ENGINE_TLS_CA_FILE` must be set and files must be readable
+- [ ] `TOKEN_ENGINE_CALLER_REGISTRY_PATH` — optional; if set, must point to a valid `caller-registry.yaml` with `version: 1`
 - [ ] jwtauth `KeyManager` key store (disk or Redis) accessible and writable
 - [ ] Redis accessible if using any Redis-backed components (v0.2+)
 
@@ -18,9 +19,15 @@ Before starting the service:
 
 ### Mutual TLS (`TLS_MODE=mtls`)
 
-The gRPC server requires client certificates. Configure TLS at the process level via your deployment platform (Kubernetes service mesh, Envoy sidecar, or direct certificate injection).
+The gRPC server requires client certificates. As of v0.5, the gRPC server loads TLS credentials
+directly from the filesystem when `TLS_MODE=mtls`. Three env vars are required:
 
-The service does not load certificates directly in v0.1 — mTLS is enforced at the transport layer by the infrastructure.
+- `TOKEN_ENGINE_TLS_CERT_FILE` — path to the server PEM certificate
+- `TOKEN_ENGINE_TLS_KEY_FILE` — path to the server PEM private key
+- `TOKEN_ENGINE_TLS_CA_FILE` — path to the CA certificate used to verify client certificates
+
+Client certificates are required (`RequireAndVerifyClientCert`). Minimum TLS version: 1.3.
+Caller identity is extracted from the client certificate's Common Name (CN) field by `MTLSAuthenticator`.
 
 ### No TLS (`TLS_MODE=disabled`)
 

--- a/doc/METRICS.md
+++ b/doc/METRICS.md
@@ -92,7 +92,7 @@ token_engine_active_tenants
 |---|---|
 | Type | Counter |
 | Description | Total number of tenant registry operations |
-| Labels | _(none)_ |
+| Labels | `operation` (`add`, `drain`, `remove`) |
 
 **PromQL examples:**
 
@@ -100,6 +100,21 @@ token_engine_active_tenants
 # Registry operation rate
 rate(token_engine_tenant_registry_operations_total[5m])
 ```
+
+---
+
+---
+
+## Planned Metrics (v0.6)
+
+### token_engine_jwks_key_count
+
+| Field | Value |
+|---|---|
+| Type | Gauge |
+| Description | Number of non-expired public keys currently available in the JWKS endpoint, per tenant |
+| Labels | `tenant_id` |
+| Purpose | Canary for key rotation instability — alert if count drops to 0 for any tenant |
 
 ---
 

--- a/doc/adr/ADR-011-cursor-based-reconciler.md
+++ b/doc/adr/ADR-011-cursor-based-reconciler.md
@@ -1,0 +1,71 @@
+# ADR-011: Cursor-Based Reconciler
+
+**Status:** Planned (v0.6)
+**Date:** —
+
+## Context
+
+The idempotency store holds `SET NX` records for each `IssueToken` and (in v0.6+) `RefreshToken`
+call. These records have a finite TTL (default 24h). In a healthy system, every idempotency record
+corresponds to a live token in the refresh store. However, clock skew, Redis eviction under memory
+pressure, or a service restart between `SetNX` and the handler response can create orphaned tokens:
+refresh tokens in the store with no corresponding idempotency record. These orphans are harmless
+for correctness but accumulate silently.
+
+The `Reconciler` interface has been present since v0.1 with a `NoOpReconciler` stub. v0.6 promotes
+it to a real implementation.
+
+## Decision
+
+Implement a cursor-based, best-effort reconciler that:
+
+1. Pages through the refresh store for a given tenant using a persistent cursor stored in Redis
+   at `reconciliation:cursor:{tenant_id}`
+2. For each token found, checks validity — orphaned tokens are revoked
+3. Holds a per-operation distributed lock (`locks:reconciliation:{tenant_id}`) during the scan
+   to prevent concurrent reconciliation runs across replicas
+4. Resumes from the stored cursor position on restart — the scan is safe to interrupt at any
+   page boundary
+5. Does not retry failed individual revocations — best-effort, async model
+
+## Rationale
+
+**Cursor-based pagination:** Scanning the full refresh store in a single pass would block Redis
+under high token volume. A cursor allows the reconciler to yield between pages and be interrupted
+safely.
+
+**Persistent cursor in Redis:** Storing the cursor at `reconciliation:cursor:{tenant_id}` ensures
+the reconciler resumes from where it stopped after a pod restart rather than restarting the full
+scan.
+
+**Best-effort, not compensating:** Orphaned tokens do not represent a security risk — they are
+valid tokens that lack an idempotency record. A compensating rollback model would add complexity
+with minimal benefit.
+
+**Distributed lock:** Multiple replicas running concurrent scans against the same tenant's store
+would produce duplicate revocations (idempotent) but unnecessary Redis load. A short-lived lock
+prevents this without requiring a leader election mechanism.
+
+**Single-replica constraint lifted at v0.6:** Pre-v0.6 deployments must run as single replica.
+The cursor-based reconciler, combined with per-operation locks for key rotation, lifts this
+constraint.
+
+## Consequences
+
+**Positive:**
+- Orphaned tokens are eventually cleaned up without operator intervention.
+- Reconciliation is resumable across restarts — no full rescan on restart.
+- Multiple replicas can coexist safely.
+- Best-effort model keeps implementation simple.
+
+**Negative:**
+- Adds a background goroutine and Redis cursor state per tenant.
+- Cursor TTL must be tuned relative to key rotation interval and expected token volume.
+- A bug that incorrectly identifies live tokens as orphans would silently revoke valid tokens
+  — conservative orphan detection heuristic and test coverage are essential.
+
+## References
+
+- `internal/reconciliation/reconciler.go` — `Reconciler` interface
+- `internal/reconciliation/lock.go` — distributed lock implementation (v0.6)
+- `doc/ARCHITECTURE.md` — Roadmap, Interface Seams section

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -8,3 +8,4 @@
 | [ADR-004](ADR-004-noop-stubs-v01.md) | NoOp Stubs for v0.1 | Accepted | 2026-05-26 |
 | [ADR-005](ADR-005-in-memory-idempotency-v01.md) | In-Memory Idempotency Store for v0.1 | Accepted | 2026-05-26 |
 | [ADR-006](ADR-006-interceptor-chain-order.md) | Interceptor Chain Order | Accepted | 2026-05-26 |
+| [ADR-011](ADR-011-cursor-based-reconciler.md) | Cursor-Based Reconciler | Planned (v0.6) | — |


### PR DESCRIPTION
## Summary

- Roadmap updated across `ARCHITECTURE.md` and `README.md`: v0.5 marked **Complete**, v1.0 renamed to **v0.6** with updated description matching the arc document
- Component model, interface seams, and request lifecycle in `ARCHITECTURE.md` updated to reflect `MultiTenantRegistry`, YAML-backed `StaticCallerRegistry`, and `MTLSAuthenticator`
- `ADR-011-cursor-based-reconciler.md` added — full ADR body covering cursor at `reconciliation:cursor:{tenant_id}`, distributed lock, best-effort model, resumable-across-restarts property
- `DEPLOYMENT.md` TLS section rewritten to describe v0.5 certificate loading; pre-flight checklist updated with TLS cert vars and `CALLER_REGISTRY_PATH`
- `METRICS.md` `tenant_registry_operations_total` labels corrected (`operation` = `add`/`drain`/`remove`); planned v0.6 `token_engine_jwks_key_count` gauge documented
- `README.md` updated: `RevokeAllForUserAndAudience` in RPC table + API reference; 4 new v0.5 config vars; interceptor chain description updated for mTLS
- `CHANGELOG.md` `[Unreleased]` section populated with full v0.5.0 deliverables and v0.6 deferrals

## Test plan

- [x] Verify `v1.0` does not appear in roadmap tables (`doc/ARCHITECTURE.md`, `README.md`)
- [x] Verify `v0.5` shows Complete and `v0.6` shows Planned
- [x] Verify ADR-011 referenced in `doc/ARCHITECTURE.md` and `doc/adr/README.md`
- [x] Verify `operation` label present in `doc/METRICS.md` for `tenant_registry_operations_total`
- [x] Verify stale "does not load certificates" statement absent from `doc/DEPLOYMENT.md`
- [x] Verify `RevokeAllForUserAndAudience` present in `README.md` RPC table and API reference