### PR TITLE
feat: add NoOpLocker and NoOpLock to internal/lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `NoOpLocker` and `NoOpLock` to `internal/lock` — no-op implementations of the `Locker` and `Lock` interfaces for use in single-node deployments and unit tests that do not require distributed mutual exclusion
+
 ### Changed
 
 - Upgraded jwtauth dependency from v0.7.2 to v1.0.0; wired `Namespace` field on `RedisKeyStoreConfig` and `RedisRefreshStoreConfig` for per-tenant observability label decoupling

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -148,4 +148,36 @@ var _ = Describe("Lock", func() {
 			})
 		})
 	})
+
+	// ===== PHASE 4: NoOpLocker =====
+	Describe("Phase 4: NoOpLocker", func() {
+		var noopLocker *NoOpLocker
+
+		BeforeEach(func() {
+			noopLocker = NewNoOpLocker()
+		})
+
+		It("returns a non-nil NoOpLocker from NewNoOpLocker", func() {
+			Expect(noopLocker).NotTo(BeNil())
+		})
+
+		It("returns a non-nil Lock and nil error from Acquire", func() {
+			lk, err := noopLocker.Acquire(ctx, "any-key", time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lk).NotTo(BeNil())
+		})
+
+		It("returns nil from Release", func() {
+			lk, err := noopLocker.Acquire(ctx, "any-key", time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lk.Release(ctx)).To(Succeed())
+		})
+
+		It("allows Release to be called multiple times (idempotent)", func() {
+			lk, err := noopLocker.Acquire(ctx, "any-key", time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lk.Release(ctx)).To(Succeed())
+			Expect(lk.Release(ctx)).To(Succeed())
+		})
+	})
 })

--- a/internal/lock/noop.go
+++ b/internal/lock/noop.go
@@ -1,0 +1,37 @@
+package lock
+
+import (
+	"context"
+	"time"
+)
+
+// NoOpLocker is a no-op implementation of Locker that always succeeds without
+// acquiring any real lock. Suitable for single-node deployments and unit tests
+// that do not require distributed mutual exclusion. All methods are safe for
+// concurrent use.
+type NoOpLocker struct{}
+
+var _ Locker = (*NoOpLocker)(nil)
+
+// NoOpLock is a no-op implementation of Lock returned by NoOpLocker.Acquire.
+// Release is always a no-op. All methods are safe for concurrent use.
+type NoOpLock struct{}
+
+var _ Lock = (*NoOpLock)(nil)
+
+// NewNoOpLocker returns a new NoOpLocker.
+func NewNoOpLocker() *NoOpLocker {
+	return &NoOpLocker{}
+}
+
+// Acquire returns a NoOpLock immediately without contacting any store.
+// It never returns an error.
+func (l *NoOpLocker) Acquire(_ context.Context, _ string, _ time.Duration) (Lock, error) {
+	return &NoOpLock{}, nil
+}
+
+// Release is a no-op. It is idempotent — it always returns nil regardless of
+// how many times it is called.
+func (l *NoOpLock) Release(_ context.Context) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds `NoOpLocker` and `NoOpLock` to `internal/lock` — no-op implementations of the `Locker` and `Lock` interfaces. This fills a gap in the NoOp pattern (coding-standard.md rule 2): every interface exposed to callers must have a corresponding NoOp so constructors can inject a safe zero-value without a Redis dependency.

## Changes

- **`internal/lock/noop.go`** (new): `NoOpLocker`, `NoOpLock`, `NewNoOpLocker()`, compile-time assertions
- **`internal/lock/lock_test.go`**: Phase 4 — 4 new specs covering `Acquire`, `Release`, and idempotency (Lock Suite: 9 → 13 specs)
- **`CHANGELOG.md`**: `### Added` entry under `[Unreleased]`

## Acceptance criteria

- [x] `NoOpLocker` and `NoOpLock` satisfy their respective interfaces at compile time (`var _ Locker = (*NoOpLocker)(nil)`, `var _ Lock = (*NoOpLock)(nil)`)
- [x] `NewNoOpLocker()` callable without any dependencies
- [x] `Acquire` returns non-nil `Lock` and nil error unconditionally
- [x] `Release` returns nil and is idempotent
- [x] `make ci` green — 0 lint issues, 10/10 suites pass with `-race`, Lock Suite 13/13 specs

## ADR compliance

- **ADR-004**: NoOp stubs for seam-first design — this directly fulfils the same principle for the lock package ✓

Closes #42