### PR TITLE
docs: fix stale IntrospectToken RPC reference in operator guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `docs/operator-guide.md` Architecture Overview to remove the non-existent `IntrospectToken` RPC and add the missing `RevokeAllUserTokens` and `RevokeAllForUserAndAudience` RPCs; the list now matches `proto/token_engine.proto` exactly
+
 ---
 
 ## [v0.6.0] — 2026-06-03

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -4,7 +4,7 @@
 
 Token Engine exposes two network interfaces:
 
-- **gRPC** on `:9090` — handles `IssueToken`, `RefreshToken`, `RevokeToken`, `RevokeAllForAudience`, and `IntrospectToken` RPCs.
+- **gRPC** on `:9090` — handles `IssueToken`, `RefreshToken`, `RevokeToken`, `RevokeAllForAudience`, `RevokeAllUserTokens`, and `RevokeAllForUserAndAudience` RPCs.
 - **HTTP** on `:8080` — serves JWKS at `/.well-known/jwks.json`, health endpoints at `/healthz/live` and `/healthz/ready`, and Prometheus metrics at `/metrics`.
 
 Both listeners start simultaneously. The gRPC port is the primary RPC surface; the HTTP port is read-only and supports health probes and metric scraping. Startup probes should target the HTTP port to avoid gating readiness on gRPC listener availability.


### PR DESCRIPTION
## Summary

- Removes `IntrospectToken` from the Architecture Overview RPC list in `docs/operator-guide.md` — this RPC does not exist in `proto/token_engine.proto` and is not registered in `main.go`
- Adds the two RPCs that were missing from the guide: `RevokeAllUserTokens` and `RevokeAllForUserAndAudience`
- The RPC list on line 7 now matches `proto/token_engine.proto` exactly (six RPCs)
- Updates `CHANGELOG.md` `[Unreleased]` with a `### Fixed` entry

Closes #43

## Test plan

- [ ] `grep -n "IntrospectToken" docs/operator-guide.md` returns no results
- [ ] `docs/operator-guide.md` line 7 lists all six RPCs from `proto/token_engine.proto` in order