### PR TITLE
docs: supersede ADR-003 with mTLS outcome and retract v0.2 CallerRegistry promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated ADR-003 status to Superseded; replaced stale Target Version note with an Outcome section documenting mTLS delivery in v0.5.0, coexistence with static key auth, and a forward reference to ADR-008
+
 ### Fixed
 
 - Fixed `docs/operator-guide.md` Architecture Overview to remove the non-existent `IntrospectToken` RPC and add the missing `RevokeAllUserTokens` and `RevokeAllForUserAndAudience` RPCs; the list now matches `proto/token_engine.proto` exactly

--- a/doc/adr/ADR-003-static-caller-keys-v01.md
+++ b/doc/adr/ADR-003-static-caller-keys-v01.md
@@ -1,6 +1,6 @@
 # ADR-003: Static Caller Keys for v0.1
 
-**Status:** Accepted  
+**Status:** Superseded — mTLS delivered in v0.5.0; see ADR-008  
 **Date:** 2026-05-26
 
 ## Context
@@ -33,12 +33,17 @@ Static API key → caller identity map for v0.1. Keys are configured via `TOKEN_
 - Key revocation is not immediate — the service must be restarted to revoke a key.
 - Static keys stored in environment variables require secrets management discipline at the deployment layer (Kubernetes Secrets, Vault agent injection, etc.).
 
-## Target Version
+## Outcome
 
-v0.2 will introduce a Redis-backed `CallerRegistry` that supports key rotation without restart and immediate revocation.
+mTLS authentication (`TLS_MODE=mtls`) was delivered in v0.5.0 via `MTLSAuthenticator`, which extracts caller identity from the TLS client certificate Common Name. The full mTLS design rationale is documented in ADR-008.
+
+Static key authentication remains the production path when `TLS_MODE=disabled`. The two modes are mutually exclusive at startup — `TLS_MODE` determines which `Authenticator` implementation is wired in `main.go`.
+
+The Redis-backed `CallerRegistry` referenced in the original Target Version note was not pursued — `StaticCallerRegistry` meets current requirements without the operational overhead of Redis key management.
 
 ## References
 
 - [internal/interceptor/auth.go](../../internal/interceptor/auth.go) — StaticKeyAuthenticator
 - [internal/registry/caller.go](../../internal/registry/caller.go) — StaticCallerRegistry
 - [ADR-006](ADR-006-interceptor-chain-order.md) — where in the chain authentication runs
+- [ADR-008](ADR-008-mtls-auth-model.md) — mTLS design rationale and CN-based identity model


### PR DESCRIPTION
## Summary

- Updates ADR-003 status to **Superseded — mTLS delivered in v0.5.0; see ADR-008**
- Replaces the stale "Target Version" section with an "Outcome" section that documents: `MTLSAuthenticator` CN extraction as the production path for `TLS_MODE=mtls`, static key auth remaining for `TLS_MODE=disabled`, and explicitly retracts the v0.2 Redis-backed `CallerRegistry` promise that was never pursued
- Adds a forward reference to ADR-008 in the References section
- Updates `CHANGELOG.md` `[Unreleased]` with a `### Changed` entry

Closes #44
Partially resolves #63 — checks off the ADR-003 item (retract/update the Target Version note)

## Test plan

- [ ] ADR-003 status line reads "Superseded — mTLS delivered in v0.5.0; see ADR-008"
- [ ] `grep "Target Version" doc/adr/ADR-003-static-caller-keys-v01.md` returns no results
- [ ] Outcome section present with mTLS coexistence note and CallerRegistry retraction
- [ ] ADR-008 forward reference appears in References