### PR TITLE
docs: correct ADR-002, ADR-004, ADR-005, ADR-006 against current implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated ADR-003 status to Superseded; replaced stale Target Version note with an Outcome section documenting mTLS delivery in v0.5.0, coexistence with static key auth, and a forward reference to ADR-008
+- Corrected ADR-002 jwtauth pinned version (v0.7.0 → v0.7.2); updated ADR-004 with production implementation outcomes (SlogAuditStore, CursorReconciler, MultiTenantRegistry); rewrote ADR-005 to Superseded with RedisIdempotencyStore delivery, 24h TTL default, RefreshToken coverage, and pre-handler ordering invariant; corrected ADR-006 interceptor naming and idempotency scope; updated ADR README to reflect ADR-003 and ADR-005 Superseded status
 
 ### Fixed
 

--- a/doc/adr/ADR-002-jwtauth-library-delegation.md
+++ b/doc/adr/ADR-002-jwtauth-library-delegation.md
@@ -37,7 +37,7 @@ token-engine contains no JWT signing code, no key management code, and no refres
 
 | Dependency | Pinned Version | Reason |
 |---|---|---|
-| `github.com/aetomala/jwtauth` | v0.7.0 | Sentinel package layout (v0.7.0 specific) |
+| `github.com/aetomala/jwtauth` | v0.7.2 | Sentinel package layout and TokenManager interface (v0.7.2 specific) |
 | `go.uber.org/mock` | v0.6.0 | Required by jwtauth v0.7.0 |
 | `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` | v0.52.0 | v0.60.0+ dropped `UnaryServerInterceptor`; incompatible with `ChainUnaryInterceptor` pattern |
 

--- a/doc/adr/ADR-004-noop-stubs-v01.md
+++ b/doc/adr/ADR-004-noop-stubs-v01.md
@@ -39,6 +39,18 @@ Define interfaces and NoOp implementations for all three components. Wire the No
 - No audit trail in v0.1 — token operations are not recorded anywhere beyond log lines.
 - No automatic cleanup of expired tokens in v0.1 — orphaned refresh tokens accumulate in the jwtauth `RefreshStore` until it is restarted or the store is manually cleared.
 
+## Outcome
+
+Two of the three NoOp stubs have been superseded by real implementations:
+
+- **`SlogAuditStore`** replaced `NoOpAuditStore` in v0.3.0 — writes structured log lines for
+  all revocation events and is wired in `main.go`. `NoOpAuditStore` remains available as a
+  test utility for components that need an `AuditStore` without a real logger.
+- **`CursorReconciler`** replaced `NoOpReconciler` in v0.6.0 — performs cursor-based
+  reconciliation of the Redis-backed refresh token store on a configurable interval and is
+  wired in `main.go`. `NoOpReconciler` remains available as a test utility.
+- **`MultiTenantRegistry`** replaced `StaticTenantRegistry` in v0.5.0.
+
 ## References
 
 - [internal/audit/store.go](../../internal/audit/store.go)

--- a/doc/adr/ADR-005-in-memory-idempotency-v01.md
+++ b/doc/adr/ADR-005-in-memory-idempotency-v01.md
@@ -1,6 +1,6 @@
 # ADR-005: In-Memory Idempotency Store for v0.1
 
-**Status:** Accepted  
+**Status:** Superseded — RedisIdempotencyStore delivered in v0.4.0  
 **Date:** 2026-05-26
 
 ## Context
@@ -13,23 +13,32 @@ Durable idempotency (surviving restarts, shared across replicas) requires Redis.
 
 In-memory idempotency store with configurable TTL (`TOKEN_ENGINE_IDEMPOTENCY_TTL`, default 5 minutes). The store is a `sync.Map` with a background goroutine that sweeps expired entries.
 
+This decision was superseded in v0.4.0 — see Outcome below.
+
 ## Rationale
 
 - **Request deduplication works within the TTL window.** The primary use case for idempotency is network retries — a caller retries within seconds of the original request. An in-memory store with a 5-minute TTL covers this case correctly.
-- **Interface seam.** The `IdempotencyStore` interface is defined. v0.2 replaces the in-memory implementation with a Redis-backed one. No other code changes.
-- **Acceptable limitation.** The in-memory store is per-process. In a multi-replica deployment, a retry routed to a different replica will not find the cached response and will issue a second token pair. This is documented as a known limitation.
+- **Interface seam.** The `IdempotencyStore` interface is defined. v0.4 replaces the in-memory implementation with a Redis-backed one. No other code changes.
+- **Acceptable limitation.** The in-memory store is per-process. In a multi-replica deployment, a retry routed to a different replica will not find the cached response and will issue a second token pair. This is documented as a known limitation for v0.1.
 
-## Limitations
+## Outcome
 
-- **Not durable.** Idempotency state is lost on process restart. A retry arriving after a restart will issue a new token pair.
-- **Not shared across replicas.** In a multi-replica deployment, sticky sessions or a Redis-backed store (v0.2) are required for cross-replica idempotency.
-- **Memory-bound.** High-volume deployments with large TTLs accumulate idempotency entries in memory until the sweep goroutine clears them.
+`RedisIdempotencyStore` replaced the in-memory store in v0.4.0. It is wired in `main.go` and
+provides durability and cross-replica consistency. The `TOKEN_ENGINE_IDEMPOTENCY_TTL` default is
+**24 hours** — not 5 minutes as stated in the original decision.
 
-## Target Version
+Idempotency coverage was extended to **`RefreshToken`** in v0.6.0 alongside the `IssueToken`
+coverage established in v0.1.
 
-v0.2 replaces the in-memory store with a Redis-backed implementation that provides durability and cross-replica consistency.
+**Pre-handler ordering invariant (security-relevant):** The idempotency cache check for
+`RefreshToken` must occur before the jwtauth library is called — not after. jwtauth immediately
+revokes the old refresh token on invocation. A post-handler cache check would lose the race: the
+old token is already rotated before the duplicate request can be identified. This invariant is
+enforced by the position of `IdempotencyInterceptor` in the chain — it runs before the handler,
+not after.
 
 ## References
 
 - [internal/store/idempotency.go](../../internal/store/idempotency.go)
+- [internal/store/idempotency_redis.go](../../internal/store/idempotency_redis.go)
 - [internal/interceptor/idempotency.go](../../internal/interceptor/idempotency.go)

--- a/doc/adr/ADR-006-interceptor-chain-order.md
+++ b/doc/adr/ADR-006-interceptor-chain-order.md
@@ -5,32 +5,32 @@
 
 ## Context
 
-Six cross-cutting concerns must be applied to every gRPC request: distributed tracing, correlation ID injection, API key authentication, caller authorization, request idempotency, and request validation. gRPC's `ChainUnaryInterceptor` applies them in order. The ordering has correctness, performance, and observability implications.
+Six cross-cutting concerns must be applied to every gRPC request: OTel trace span creation (via `otelgrpc.UnaryServerInterceptor`), correlation ID injection and request metrics, API key authentication, caller authorization, request idempotency, and request validation. gRPC's `ChainUnaryInterceptor` applies them in order. The ordering has correctness, performance, and observability implications.
 
 ## Decision
 
 The chain runs in this order:
 
 ```
-1. OTel tracing
-2. Correlation ID
+1. otelgrpc.UnaryServerInterceptor — trace span creation
+2. Correlation ID + request count and duration metrics
 3. Authentication
 4. Caller authorization
-5. Idempotency
+5. Idempotency (IssueToken and RefreshToken)
 6. Validation
 ```
 
 ## Rationale
 
-**OTel first:** The trace span must be started before any other interceptor so that all downstream work — including authentication failures, log lines, and the handler — is attributed to the same trace. Span creation inside the OTel interceptor attaches the trace context to the `context.Context` that all subsequent interceptors receive.
+**OTel first:** The trace span must be started before any other interceptor so that all downstream work — including authentication failures, log lines, and the handler — is attributed to the same trace. Span creation inside `otelgrpc.UnaryServerInterceptor` attaches the trace context to the `context.Context` that all subsequent interceptors receive.
 
-**Correlation ID second:** The correlation ID (a UUID) should be in the context before authentication so that auth failure log lines include the correlation ID. This makes it possible to correlate a rejected request across log aggregators without a trace ID.
+**Correlation ID second:** The correlation interceptor injects a UUID correlation ID into the context and records request count and duration metrics via Prometheus. The correlation ID should be in the context before authentication so that auth failure log lines include the correlation ID. This makes it possible to correlate a rejected request across log aggregators without a trace ID.
 
 **Authentication before authorization:** Identity must be established before permissions can be checked. An unauthenticated request cannot be authorized.
 
 **Authorization before idempotency:** Checking the idempotency store for an unauthorized caller is wasted work and could leak information about whether a previous request with that key was successful. Authorization gates access to the idempotency store.
 
-**Idempotency before validation:** A duplicate request (same idempotency key within TTL) should return the cached response immediately, before field validation runs. Validation is not needed for a request that will return an already-computed result.
+**Idempotency before validation:** A duplicate `IssueToken` or `RefreshToken` request (same idempotency key within TTL) should return the cached response immediately, before field validation runs. Validation is not needed for a request that will return an already-computed result.
 
 **Validation last:** Only requests that have passed identity checks and idempotency deduplication reach the validation step. This minimizes unnecessary parsing work and keeps the validation interceptor focused purely on business logic preconditions.
 

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -4,8 +4,8 @@
 |---|---|---|---|
 | [ADR-001](ADR-001-grpc-first-transport.md) | gRPC-First Transport | Accepted | 2026-05-26 |
 | [ADR-002](ADR-002-jwtauth-library-delegation.md) | jwtauth Library Delegation | Accepted | 2026-05-26 |
-| [ADR-003](ADR-003-static-caller-keys-v01.md) | Static Caller Keys for v0.1 | Accepted | 2026-05-26 |
+| [ADR-003](ADR-003-static-caller-keys-v01.md) | Static Caller Keys for v0.1 | Superseded | 2026-05-26 |
 | [ADR-004](ADR-004-noop-stubs-v01.md) | NoOp Stubs for v0.1 | Accepted | 2026-05-26 |
-| [ADR-005](ADR-005-in-memory-idempotency-v01.md) | In-Memory Idempotency Store for v0.1 | Accepted | 2026-05-26 |
+| [ADR-005](ADR-005-in-memory-idempotency-v01.md) | In-Memory Idempotency Store for v0.1 | Superseded | 2026-05-26 |
 | [ADR-006](ADR-006-interceptor-chain-order.md) | Interceptor Chain Order | Accepted | 2026-05-26 |
 | [ADR-011](ADR-011-cursor-based-reconciler.md) | Cursor-Based Reconciler | Planned (v0.6) | — |


### PR DESCRIPTION
## Summary

- **ADR-002**: jwtauth pinned version corrected from `v0.7.0` to `v0.7.2` in the Known Version Constraints table; reason updated to reference the `TokenManager` interface change introduced in v0.7.2
- **ADR-004**: Outcome section added — acknowledges `SlogAuditStore` (v0.3.0), `CursorReconciler` (v0.6.0), and `MultiTenantRegistry` (v0.5.0) superseded the three original NoOp stubs; notes NoOps remain available as test utilities
- **ADR-005**: status → Superseded; Limitations section removed (all three limitations resolved by Redis); Target Version replaced with Outcome documenting `RedisIdempotencyStore` delivery, 24h TTL default, `RefreshToken` coverage, and pre-handler ordering invariant (security-relevant: idempotency check must precede jwtauth call because jwtauth immediately rotates the old refresh token on invocation — a post-handler check loses the race)
- **ADR-006**: `otelgrpc.UnaryServerInterceptor` named explicitly in Context and Decision sections; correlation interceptor noted as owning request count and duration metrics; idempotency scope corrected to include `RefreshToken`
- **ADR README**: ADR-003 and ADR-005 status updated to Superseded

## Test plan

- [ ] `grep "v0.7.2" doc/adr/ADR-002-jwtauth-library-delegation.md` — hit
- [ ] `grep "SlogAuditStore" doc/adr/ADR-004-noop-stubs-v01.md` — hit in Outcome section
- [ ] `grep "Superseded" doc/adr/ADR-005-in-memory-idempotency-v01.md` — hit in status line
- [ ] `grep "24 hours" doc/adr/ADR-005-in-memory-idempotency-v01.md` — hit
- [ ] `grep "Target Version" doc/adr/ADR-005-in-memory-idempotency-v01.md` — no results
- [ ] `grep "otelgrpc.UnaryServerInterceptor" doc/adr/ADR-006-interceptor-chain-order.md` — hit
- [ ] `grep "Superseded" doc/adr/README.md` — two hits (ADR-003, ADR-005)

See #63