### PR TITLE
docs: file ADR-007 — MultiTenantRegistry lifecycle and per-tenant namespace isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Consolidated `docs/` directory into `doc/` — moved `operator-guide.md` and `pre-upgrade-runbook.md` into `doc/`; `docs/` directory removed
+- Filed ADR-007 documenting `MultiTenantRegistry` design — `Add`/`Drain`/`Remove` lifecycle rationale, two-phase shutdown semantic, and per-tenant Redis key prefix and namespace isolation
 
 ---
 

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Components with interface seams produce correct behavior (no panics, no errors) 
 |---|---|---|---|
 | Audit logging | `audit.AuditStore` | `SlogAuditStore` (structured log sink) | Live — v0.3 |
 | Token reconciliation | `reconciliation.TokenReconciler` | `CursorReconciler` (cursor-based, Redis-backed) | Live — v0.6 |
-| Dynamic tenant registry | `registry.TenantRegistry` | `MultiTenantRegistry` | Live — v0.5 |
+| Dynamic tenant registry | `registry.TenantRegistry` | `MultiTenantRegistry` | Live — v0.5 — [ADR-007](adr/ADR-007-multi-tenant-registry.md) |
 | Idempotency store | `store.IdempotencyStore` | `RedisIdempotencyStore` (24h TTL default) | Live — v0.4 |
 | Caller registry | `registry.CallerRegistry` | `StaticCallerRegistry` (YAML-backed) | Live — v0.5 |
 
@@ -218,4 +218,5 @@ Mocks are generated with `go.uber.org/mock/mockgen` in source mode. All mocks li
 | [ADR-004](adr/ADR-004-noop-stubs-v01.md) | NoOp stubs for audit, reconciliation, and tenant registry in v0.1 |
 | [ADR-005](adr/ADR-005-in-memory-idempotency-v01.md) | In-memory idempotency store for v0.1 |
 | [ADR-006](adr/ADR-006-interceptor-chain-order.md) | Interceptor chain ordering rationale |
+| [ADR-007](adr/ADR-007-multi-tenant-registry.md) | MultiTenantRegistry Add/Drain/Remove lifecycle and per-tenant namespace isolation |
 | [ADR-011](adr/ADR-011-cursor-based-reconciler.md) | Cursor-Based Reconciler | Complete — v0.6 |

--- a/doc/adr/ADR-007-multi-tenant-registry.md
+++ b/doc/adr/ADR-007-multi-tenant-registry.md
@@ -1,0 +1,107 @@
+# ADR-007: MultiTenantRegistry — Add/Drain/Remove Lifecycle and Per-Tenant Namespace Isolation
+
+**Status:** Complete — v0.5.0  
+**Date:** 2026-05-30
+
+## Context
+
+v0.1 through v0.2 wired a single static tenant directly in `main.go` using `StaticTenantRegistry`.
+Tenant identity was fixed at startup: the Issuer, Audience, and Redis connection were read from
+environment variables and a single `KeyManager` + `TokenManager` pair was created once.
+
+v0.5.0 introduced two new requirements:
+
+1. **Runtime tenant lifecycle** — tenants must be onboardable and offboardable without restarting
+   the service. A static map locked at startup cannot support this.
+2. **Per-tenant data isolation** — each tenant's JWT keys, refresh tokens, and observability
+   signals must be strictly separated. Sharing Redis key space across tenants risks key ID
+   collisions and cross-tenant metric aggregation.
+
+## Decision
+
+Replace `StaticTenantRegistry` with `MultiTenantRegistry`, which exposes a three-operation
+lifecycle: `Add`, `Drain`, and `Remove`.
+
+**`Add(ctx, tenantID, TenantConfig)`**
+
+Constructs four per-tenant components using the tenantID as both the Redis `KeyPrefix` and the
+jwtauth library `Namespace`:
+
+- `keys.RedisKeyStore` — Redis-backed key store; keys namespaced under `tenantID:`
+- `keys.Manager` — key lifecycle manager (rotation, loading, JWKS); namespace `tenantID`
+- `storage.RedisRefreshStore` — refresh token store; keys namespaced under `tenantID:`
+- `tokens.Manager` — token issuance, refresh, and revocation; namespace and issuer from config
+
+Starts the `KeyManager` before returning. Returns `codes.AlreadyExists` if the tenant is already
+registered.
+
+**`Drain(ctx, tenantID)`**
+
+Sets a boolean `draining` flag on the tenant's entry. Subsequent `Get` calls return
+`codes.NotFound`. In-flight requests that already resolved a `TokenManager` reference from a
+prior `Get` are unaffected — they hold the reference directly and do not go back through the
+registry.
+
+**`Remove(ctx, tenantID)`**
+
+Requires `Drain` first — returns `codes.FailedPrecondition` if the entry is not draining.
+Calls `km.Shutdown(ctx)` to cleanly stop the `KeyManager`, then deletes the entry from the map.
+
+## Rationale
+
+**Dynamic lifecycle over static map.** Operators need to onboard new tenants and drain retiring
+ones without a service restart. A static map initialized from environment variables has no
+mechanism for runtime mutation. `MultiTenantRegistry` provides explicit lifecycle control while
+keeping the `TenantRegistry` interface unchanged from the caller's perspective.
+
+**Two-phase shutdown — Drain then Remove.** A single-step `Remove` that immediately deletes the
+entry would race with in-flight requests: a handler that resolved a `TokenManager` via `Get`
+before the `Remove` call holds a valid reference, but any concurrent `Get` after `Remove` would
+fail. Separating the phases means Drain stops new requests from reaching the tenant while Remove
+waits for the operator to decide that in-flight work has completed — the timing of `Remove` is
+the operator's signal that the window has closed.
+
+**Natural token expiry over force-revocation.** Force-revoking all of a tenant's tokens at
+`Remove` time would require a full scan of the refresh store, add complexity, and create a
+thundering-herd of revocation events. Tokens already issued carry their own TTL. The operator
+controls the effective offboarding window by choosing how long to wait between `Drain` and
+`Remove` — long enough that any unexpired tokens the tenant was actively using have either
+expired or been refreshed under the new tenancy arrangement.
+
+**Namespace isolation via key prefix at construction.** A shared Redis key space would require
+every call site to construct a compound key from a tenant prefix — adding logic to `KeyManager`,
+`RefreshStore`, and all Redis commands. Assigning the tenantID as the `KeyPrefix` at
+construction time isolates each tenant's Redis key space without any call-site logic. The same
+tenantID flows into the jwtauth library `Namespace`, ensuring Prometheus metrics and internal
+state are also scoped per tenant.
+
+## Alternatives Considered
+
+**Single shared Redis key space** — rejected. Key ID collisions across tenants are possible when
+different tenants use the same key rotation schedule. Requires compound key construction at every
+Redis call site and does not isolate observability signals.
+
+**Per-tenant process isolation** — rejected. Deploying a separate process per tenant is
+operationally disproportionate for the granularity needed. In-process namespace isolation
+achieves the same data separation with a single binary and a shared connection pool.
+
+## Consequences
+
+**Positive:**
+- Tenants can be onboarded and offboarded at runtime without a service restart.
+- Each tenant's Redis keys, refresh tokens, JWT keys, and metrics are strictly isolated.
+- `KeyManager` lifecycle is owned by the registry — no external bookkeeping required.
+- The `TenantRegistry` interface is unchanged; callers (`TokenHandler`, health checkers, JWKS
+  handler, `CursorReconciler`) are unaffected by the implementation switch.
+
+**Negative:**
+- Callers of `Remove` must coordinate with `Drain` and wait for in-flight requests to complete.
+  There is no built-in fence — the operator provides the timing.
+- `AllKeyManagers()` and `GetAll()` must iterate the live tenant map under a read lock. These
+  methods are called by health checkers, the JWKS handler, and the reconciler on every tick.
+
+## References
+
+- [internal/registry/multi_tenant.go](../../internal/registry/multi_tenant.go)
+- [internal/registry/tenant.go](../../internal/registry/tenant.go) — `TenantRegistry` interface and `TenantConfig`
+- [doc/ARCHITECTURE.md](../ARCHITECTURE.md) — Interface Seams section

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -8,4 +8,5 @@
 | [ADR-004](ADR-004-noop-stubs-v01.md) | NoOp Stubs for v0.1 | Accepted | 2026-05-26 |
 | [ADR-005](ADR-005-in-memory-idempotency-v01.md) | In-Memory Idempotency Store for v0.1 | Superseded | 2026-05-26 |
 | [ADR-006](ADR-006-interceptor-chain-order.md) | Interceptor Chain Order | Accepted | 2026-05-26 |
+| [ADR-007](ADR-007-multi-tenant-registry.md) | Multi-Tenant Registry Lifecycle | Complete — v0.5.0 | 2026-05-30 |
 | [ADR-011](ADR-011-cursor-based-reconciler.md) | Cursor-Based Reconciler | Planned (v0.6) | — |


### PR DESCRIPTION
## Summary

- Files `doc/adr/ADR-007-multi-tenant-registry.md` covering the `MultiTenantRegistry` design decisions introduced in v0.5.0
- ADR covers: `Add`/`Drain`/`Remove` lifecycle rationale, two-phase shutdown semantic, natural token expiry over force-revocation, and per-tenant Redis key prefix + jwtauth `Namespace` isolation
- Updates ADR index (`doc/adr/README.md`), `doc/ARCHITECTURE.md` (Interface Seams table + ADR table), and `CHANGELOG.md`
- No implementation changes

## Acceptance criteria (from #46)

- [x] `doc/adr/ADR-007-multi-tenant-registry.md` filed with status: Complete — v0.5.0
- [x] ADR-007 referenced from `ARCHITECTURE.md` interface seams table row for `TenantRegistry`
- [x] No implementation changes

See #46