### PR TITLE
feat: add docker-compose.yaml for single-command local development stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `docker-compose.yaml` — single-command local stack (Redis + token-engine) with
+  `TLS_MODE=disabled` and commented environment variable documentation; runnable with
+  `docker compose up` or `podman compose up`; README.md Quick Start updated to lead with
+  the compose workflow
+
 ---
 
 ## [v0.8.0] — 2026-06-10

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ OpenTelemetry tracing → Correlation ID → Authentication (API key or mTLS CN)
 
 ## Quick Start
 
+### Using Docker Compose (recommended)
+
+```bash
+docker compose up          # Docker
+# or: podman compose up    # Podman
+```
+
+The stack starts Redis and token-engine. Once healthy:
+
+```bash
+curl http://localhost:8080/healthz/ready   # → 200 OK
+```
+
+The gRPC server is on `:9090` and the HTTP server (health, metrics, JWKS) is on `:8080`.
+See [`docker-compose.yaml`](docker-compose.yaml) for all pre-configured environment variables.
+
+### Running directly
+
 ```bash
 # Build
 make build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,63 @@
+# docker-compose.yaml
+#
+# Starts a complete local token-engine stack: Redis + token-engine.
+#
+# Usage:
+#   docker compose up          # Docker
+#   podman compose up          # Podman (requires podman-compose or Podman 4.4+)
+#
+# The service builds from the local Dockerfile. To use the published image instead:
+#   image: docker.io/angeltomala/token-engine:v0.8.0
+#
+# Health probe (from your host, after stack is up):
+#   curl http://localhost:8080/healthz/ready
+#
+# gRPC (from your host, requires grpcurl):
+#   grpcurl -plaintext -H 'x-api-key: devkey' \
+#     -d '{"sub":"user-1","tenant_id":"local-dev"}' \
+#     localhost:9090 token.v1.TokenEngine/IssueToken
+
+services:
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  token-engine:
+    build: .
+    ports:
+      - "9090:9090"   # gRPC
+      - "8080:8080"   # HTTP: /healthz/live, /healthz/ready, /metrics, /.well-known/jwks.json
+    depends_on:
+      redis:
+        condition: service_healthy
+    stop_grace_period: 60s   # allow gRPC drain (10 s) + OTel flush + HTTP shutdown
+    environment:
+      # ===== Required =====
+      # JWT iss claim — used as the tenant identifier.
+      TOKEN_ENGINE_ISSUER: local-dev
+      # JWT aud claim — must match the audience your callers expect.
+      TOKEN_ENGINE_AUDIENCE: local-api
+
+      # ===== Authentication =====
+      # TLS mode: "disabled" uses static API keys; "mtls" requires cert/key/CA files.
+      TOKEN_ENGINE_TLS_MODE: disabled
+      # Static API keys — format: key=caller-identity (comma-separated for multiple).
+      # Pass the key in the x-api-key gRPC metadata header (or Authorization: Bearer <key>).
+      TOKEN_ENGINE_STATIC_CALLER_KEYS: devkey=local-client
+
+      # ===== Redis =====
+      # Must use the compose service name ("redis"), not "localhost".
+      TOKEN_ENGINE_REDIS_ADDR: redis:6379
+      # TOKEN_ENGINE_REDIS_PASSWORD:   # set if your Redis requires a password
+      # TOKEN_ENGINE_REDIS_DB: 0       # Redis database index (default: 0)
+
+      # ===== Optional observability =====
+      # Uncomment to export OTLP traces to a local collector (e.g. Jaeger, Tempo).
+      # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317


### PR DESCRIPTION
## Summary

- New `docker-compose.yaml` at repo root starts Redis 7-alpine + token-engine with a single `docker compose up` (or `podman compose up`)
- Redis `redis-cli ping` healthcheck gates token-engine startup via `depends_on: condition: service_healthy`
- `stop_grace_period: 60s` allows gRPC 10 s drain + OTel flush before Docker kills the container
- Every environment variable in the compose file has an inline comment explaining its purpose
- `README.md` Quick Start section reorganized to lead with Docker Compose, keeping bare-metal instructions as a secondary option

## Test plan

- [ ] `make ci` passes (lint + build + 343 specs) — verified locally
- [ ] `docker compose up --build` starts both services successfully
- [ ] `curl http://localhost:8080/healthz/ready` returns 200
- [ ] `curl http://localhost:8080/healthz/live` returns 200
- [ ] `docker compose down` completes cleanly within `stop_grace_period`
- [ ] `podman compose up` also works (Podman is the local container runtime)

Closes #52