### PR TITLE
feat: add examples/multi-tenant with cross-tenant isolation demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   map and validating the returned access token against the JWKS endpoint using
   `golang-jwt/jwt/v5`; demonstrates the top-level claim promotion behaviour
 - Added `examples/README.md` — index for all three client examples with usage commands
+- Added `examples/multi-tenant` — runnable example issuing and refreshing tokens for two
+  independent tenant-alpha and tenant-beta server instances; demonstrates cross-tenant token
+  rejection and documents Redis key namespace isolation via source comments; includes a
+  self-contained `docker-compose.yaml` and a two-tenant `caller-registry.yaml` reference
+- Updated `examples/README.md` — added comparison table covering all four client examples
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,13 @@ docker compose up   # or: podman compose up
 See [`docker-compose.yaml`](../docker-compose.yaml) for the default credentials
 (`devkey=local-client`, issuer `local-dev`, audience `local-api`).
 
+| Example | Auth | Demonstrates |
+|---|---|---|
+| `grpc-client` | Static API key | Minimal gRPC client — `IssueToken` and token pair output |
+| `mtls-client` | mTLS certificate | Certificate-based auth with `WithMTLS` |
+| `custom-claims` | Static API key | Custom claims issuance and JWKS-based JWT validation |
+| `multi-tenant` | Static API key | Per-tenant isolation and cross-tenant token rejection |
+
 ---
 
 ## grpc-client
@@ -46,3 +53,19 @@ TOKEN_ENGINE_STATIC_KEY=devkey go run ./examples/custom-claims
 
 Custom claims in `IssueTokenRequest.Claims` are promoted to top-level JWT fields — they
 are not nested under a `"claims"` key in the token payload.
+
+## multi-tenant
+
+Runs two token-engine instances (tenant-alpha on `:9090`, tenant-beta on `:9091`) sharing
+a single Redis. Issues and refreshes tokens for each tenant, then demonstrates that a
+refresh token issued for one tenant is rejected when presented with a different tenant ID.
+
+```bash
+docker compose -f examples/multi-tenant/docker-compose.yaml up -d
+sleep 10
+TOKEN_ENGINE_STATIC_KEY=devkey go run ./examples/multi-tenant
+docker compose -f examples/multi-tenant/docker-compose.yaml down
+```
+
+See `examples/multi-tenant/caller-registry.yaml` for a two-tenant mTLS caller authorization
+reference.

--- a/examples/multi-tenant/caller-registry.yaml
+++ b/examples/multi-tenant/caller-registry.yaml
@@ -1,0 +1,13 @@
+# caller-registry.yaml — static caller authorization for the multi-tenant example.
+# Maps TLS certificate Common Names to permitted tenant IDs.
+# In TLS_MODE=disabled deployments this file is not consulted; it is included here
+# as a reference for mTLS multi-tenant deployments (TOKEN_ENGINE_CALLER_REGISTRY_PATH).
+version: 1
+callers:
+  - identity: "alpha-service"
+    permitted_tenants:
+      - "tenant-alpha"
+  - identity: "admin-service"
+    permitted_tenants:
+      - "tenant-alpha"
+      - "tenant-beta"

--- a/examples/multi-tenant/docker-compose.yaml
+++ b/examples/multi-tenant/docker-compose.yaml
@@ -1,0 +1,51 @@
+# Runs two isolated token-engine instances on shared Redis — demonstrating per-tenant
+# key namespace isolation without requiring code changes to the server.
+#
+# Usage:
+#   docker compose up    # from this directory
+#   podman compose up
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  token-engine-alpha:
+    build:
+      context: ../..
+    ports:
+      - "9090:9090"
+      - "8080:8080"
+    depends_on:
+      redis:
+        condition: service_healthy
+    stop_grace_period: 60s
+    environment:
+      TOKEN_ENGINE_ISSUER: tenant-alpha
+      TOKEN_ENGINE_AUDIENCE: alpha-api
+      TOKEN_ENGINE_TLS_MODE: disabled
+      TOKEN_ENGINE_STATIC_CALLER_KEYS: devkey=local-client
+      TOKEN_ENGINE_REDIS_ADDR: redis:6379
+
+  token-engine-beta:
+    build:
+      context: ../..
+    ports:
+      - "9091:9090"
+      - "8081:8080"
+    depends_on:
+      redis:
+        condition: service_healthy
+    stop_grace_period: 60s
+    environment:
+      TOKEN_ENGINE_ISSUER: tenant-beta
+      TOKEN_ENGINE_AUDIENCE: beta-api
+      TOKEN_ENGINE_TLS_MODE: disabled
+      TOKEN_ENGINE_STATIC_CALLER_KEYS: devkey=local-client
+      TOKEN_ENGINE_REDIS_ADDR: redis:6379

--- a/examples/multi-tenant/main.go
+++ b/examples/multi-tenant/main.go
@@ -1,0 +1,138 @@
+// Example: per-tenant token isolation with two independent token-engine instances.
+//
+// Prerequisites:
+//   - Two token-engine servers running — see docker-compose.yaml in this directory:
+//       docker compose up   # or: podman compose up
+//
+// Usage:
+//
+//	TOKEN_ENGINE_STATIC_KEY=devkey go run ./examples/multi-tenant
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aetomala/token-engine/client"
+	tokenv1 "github.com/aetomala/token-engine/gen/v1"
+)
+
+func main() {
+	alphaAddr := envOrDefault("TOKEN_ENGINE_ALPHA_ADDR", "localhost:9090")
+	betaAddr  := envOrDefault("TOKEN_ENGINE_BETA_ADDR", "localhost:9091")
+	key       := envOrDefault("TOKEN_ENGINE_STATIC_KEY", "devkey")
+
+	// ===== Connect to both tenant servers =====
+	alphaClient, err := client.NewClient(alphaAddr,
+		client.WithPlaintext(),
+		client.WithStaticKey(key),
+	)
+	if err != nil {
+		log.Fatalf("client.NewClient (alpha): %v", err)
+	}
+	defer func() {
+		if err := alphaClient.Close(); err != nil {
+			log.Printf("close alpha: %v", err)
+		}
+	}()
+
+	betaClient, err := client.NewClient(betaAddr,
+		client.WithPlaintext(),
+		client.WithStaticKey(key),
+	)
+	if err != nil {
+		log.Fatalf("client.NewClient (beta): %v", err)
+	}
+	defer func() {
+		if err := betaClient.Close(); err != nil {
+			log.Printf("close beta: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// ===== Issue tokens — tenant-alpha =====
+	// tenant_id must match the issuer registered on the target server.
+	// Each server registers exactly one tenant at startup via TOKEN_ENGINE_ISSUER.
+	alphaPair, err := alphaClient.IssueToken(ctx, &tokenv1.IssueTokenRequest{
+		Sub:      "user-123",
+		TenantId: "tenant-alpha",
+	})
+	if err != nil {
+		log.Fatalf("IssueToken (alpha): %v", err)
+	}
+	fmt.Printf("[tenant-alpha] access_token:  %s\n", alphaPair.GetAccessToken())
+	fmt.Printf("[tenant-alpha] refresh_token: %s\n\n", alphaPair.GetRefreshToken())
+
+	// Issue a second token for the cross-tenant rejection test below — kept separate
+	// so it is not rotated before it is used.
+	alpha2, err := alphaClient.IssueToken(ctx, &tokenv1.IssueTokenRequest{
+		Sub:      "cross-test-user",
+		TenantId: "tenant-alpha",
+	})
+	if err != nil {
+		log.Fatalf("IssueToken (alpha/cross-test): %v", err)
+	}
+
+	// ===== Issue tokens — tenant-beta =====
+	betaPair, err := betaClient.IssueToken(ctx, &tokenv1.IssueTokenRequest{
+		Sub:      "user-456",
+		TenantId: "tenant-beta",
+	})
+	if err != nil {
+		log.Fatalf("IssueToken (beta): %v", err)
+	}
+	fmt.Printf("[tenant-beta]  access_token:  %s\n", betaPair.GetAccessToken())
+	fmt.Printf("[tenant-beta]  refresh_token: %s\n\n", betaPair.GetRefreshToken())
+
+	// ===== RefreshToken — tenant-alpha =====
+	// Rotates the access+refresh pair. The old refresh token is revoked atomically.
+	alphaRefreshed, err := alphaClient.RefreshToken(ctx, &tokenv1.RefreshTokenRequest{
+		RefreshToken: alphaPair.GetRefreshToken(),
+		TenantId:     "tenant-alpha",
+	})
+	if err != nil {
+		log.Fatalf("RefreshToken (alpha): %v", err)
+	}
+	fmt.Printf("[tenant-alpha] refreshed access_token: %s\n\n", alphaRefreshed.GetAccessToken())
+
+	// ===== RefreshToken — tenant-beta =====
+	betaRefreshed, err := betaClient.RefreshToken(ctx, &tokenv1.RefreshTokenRequest{
+		RefreshToken: betaPair.GetRefreshToken(),
+		TenantId:     "tenant-beta",
+	})
+	if err != nil {
+		log.Fatalf("RefreshToken (beta): %v", err)
+	}
+	fmt.Printf("[tenant-beta]  refreshed access_token: %s\n\n", betaRefreshed.GetAccessToken())
+
+	// ===== Cross-tenant isolation =====
+	// Present tenant-alpha's refresh token to the alpha server but claim it belongs
+	// to "tenant-beta". The alpha server has only "tenant-alpha" registered; it has
+	// no record of "tenant-beta" and returns NOT_FOUND.
+	//
+	// In Redis, each tenant's tokens are stored under an isolated key prefix:
+	//   tenant-alpha: "tenant-alpha:refresh:<token-id>"
+	//   tenant-beta:  "tenant-beta:refresh:<token-id>"
+	// A token issued under one prefix cannot be found — or validated — under another.
+	_, err = alphaClient.RefreshToken(ctx, &tokenv1.RefreshTokenRequest{
+		RefreshToken: alpha2.GetRefreshToken(),
+		TenantId:     "tenant-beta",
+	})
+	if err != nil {
+		fmt.Printf("[cross-tenant] RefreshToken correctly rejected: %v\n", err)
+	} else {
+		log.Fatal("[cross-tenant] RefreshToken succeeded — tenant isolation broken")
+	}
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}


### PR DESCRIPTION
## Summary

- Adds `examples/multi-tenant/` — a self-contained example demonstrating per-tenant token isolation using two independent token-engine instances (tenant-alpha on `:9090`, tenant-beta on `:9091`) sharing a single Redis container
- Includes `docker-compose.yaml` (two-server stack with `build: context: ../..`), `caller-registry.yaml` (two-tenant mTLS reference), and `main.go` (IssueToken + RefreshToken + cross-tenant rejection demonstration)
- Updates `examples/README.md` with a comparison table covering all four client examples
- Updates `CHANGELOG.md` `[Unreleased] ### Added`

## What the example shows

1. `IssueToken` for tenant-alpha and tenant-beta using separate clients
2. `RefreshToken` for each tenant (correct tenant_id, correct server)
3. Cross-tenant rejection: alpha's refresh token presented to alpha server with `TenantId="tenant-beta"` → `NOT_FOUND` (tenant-beta not registered on alpha instance)
4. Source comment explaining Redis key namespace isolation (`tenant-alpha:refresh:<id>` vs `tenant-beta:refresh:<id>`)

## Test plan

- [ ] `make ci` passes (lint + build + 11 test suites) — verified locally
- [ ] `go build ./examples/multi-tenant` compiles cleanly
- [ ] `docker compose -f examples/multi-tenant/docker-compose.yaml up -d && TOKEN_ENGINE_STATIC_KEY=devkey go run ./examples/multi-tenant` produces expected output with cross-tenant rejection on last line

Closes #56