### PR TITLE
fix: use NoOpCallerRegistry when no caller registry file is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed empty caller registry in `TLS_MODE=disabled` denying every tenant-scoped RPC; when no
+  `TOKEN_ENGINE_CALLER_REGISTRY_PATH` is set, all callers are now permitted and a startup warning
+  is logged — mTLS mode is unaffected and still requires an explicit registry file
+
 ### Added
 
 - Added `NewReconcilerChecker` health check — `/healthz/ready` now reports `reconciler` as

--- a/cmd/token-engine/main.go
+++ b/cmd/token-engine/main.go
@@ -195,7 +195,8 @@ func main() {
 		}
 		callerReg = registry.NewStaticCallerRegistry(callerCfg, logger)
 	} else {
-		callerReg = registry.NewStaticCallerRegistry(&registry.CallerRegistryConfig{Version: 1}, logger)
+		logger.Warn(ctx, "no caller registry path configured; all callers are permitted for all tenants — not safe for production")
+		callerReg = registry.NewNoOpCallerRegistry()
 	}
 
 	// ===== Audit and Reconciliation =====

--- a/integration/token_engine_test.go
+++ b/integration/token_engine_test.go
@@ -79,14 +79,10 @@ var _ = BeforeSuite(func() {
 
 	// ===== Interceptors (same order as main.go, otelgrpc skipped — noop OTel not needed) =====
 	auth := interceptor.NewStaticKeyAuthenticator(cfg.StaticCallerKeys)
-	callerReg := registry.NewStaticCallerRegistry(&registry.CallerRegistryConfig{
-		Version: 1,
-		Callers: []registry.CallerEntry{
-			// test-caller is permitted for test-issuer (normal flow) and unknown-tenant
-			// (so the "unknown tenant" integration test reaches the registry and gets NotFound).
-			{Identity: "test-caller", PermittedTenants: []string{"test-issuer", "unknown-tenant"}},
-		},
-	}, logger)
+	// NoOpCallerRegistry mirrors the production TLS-disabled path when no registry file is
+	// configured — all callers are permitted. The unknown-tenant test still reaches the handler
+	// and gets NotFound from the MultiTenantRegistry.
+	callerReg := registry.NewNoOpCallerRegistry()
 
 	correlationInterceptor := observability.NewCorrelationInterceptor(logger, metrics)
 	authInterceptor := interceptor.NewAuthInterceptor(auth, logger)
@@ -202,6 +198,22 @@ var _ = Describe("TokenEngine", func() {
 				})
 
 				Expect(status.Code(err)).To(Equal(codes.NotFound))
+			})
+		})
+
+		Context("when no caller registry file is configured (allow-all registry)", func() {
+			It("permits the caller and returns a token pair", func() {
+				ctx, cancel := authCtx()
+				defer cancel()
+
+				resp, err := client.IssueToken(ctx, &tokenv1.IssueTokenRequest{
+					Sub:      "user-allow-all",
+					TenantId: "test-issuer",
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.AccessToken).NotTo(BeEmpty())
+				Expect(resp.RefreshToken).NotTo(BeEmpty())
 			})
 		})
 	})

--- a/internal/registry/caller.go
+++ b/internal/registry/caller.go
@@ -77,7 +77,8 @@ func NewStaticCallerRegistry(cfg *CallerRegistryConfig, logger observability.Log
 }
 
 // IsPermitted returns true if callerIdentity is authorized to operate on tenantID.
-// If tenantID is empty, returns (true, nil) — validation interceptor handles the required check.
+// If tenantID is empty, returns (true, nil) — the handler resolves the tenant from the registry
+// and returns NotFound for an unknown or empty tenant_id.
 // Returns (false, codes.PermissionDenied) if callerIdentity is not in the registry or tenantID
 // is not in the caller's permitted_tenants list.
 func (r *StaticCallerRegistry) IsPermitted(_ context.Context, callerIdentity string, tenantID string) (bool, error) {

--- a/internal/registry/noop.go
+++ b/internal/registry/noop.go
@@ -1,0 +1,20 @@
+package registry
+
+import "context"
+
+// NoOpCallerRegistry is a CallerRegistry that permits every caller for every tenant.
+// Suitable for TLS-disabled development deployments where no caller registry file is configured.
+// All methods are safe for concurrent use.
+type NoOpCallerRegistry struct{}
+
+var _ CallerRegistry = (*NoOpCallerRegistry)(nil)
+
+// NewNoOpCallerRegistry returns a NoOpCallerRegistry that allows all callers for all tenants.
+func NewNoOpCallerRegistry() *NoOpCallerRegistry {
+	return &NoOpCallerRegistry{}
+}
+
+// IsPermitted always returns (true, nil) — all callers are permitted.
+func (r *NoOpCallerRegistry) IsPermitted(_ context.Context, _ string, _ string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
## Summary

- Adds `NoOpCallerRegistry` to `internal/registry` — satisfies the coding standard requirement for a NoOp per interface; always returns `(true, nil)`
- In `TLS_MODE=disabled` with no `TOKEN_ENGINE_CALLER_REGISTRY_PATH`, `main.go` now wires `NoOpCallerRegistry` instead of an empty `StaticCallerRegistry`; logs a startup warning
- Fixes stale comment in `StaticCallerRegistry.IsPermitted` — the validation interceptor never checks `tenant_id`; the handler resolves the tenant and returns `NotFound`
- Switches the integration test `BeforeSuite` to `NoOpCallerRegistry` (mirrors the production quick-start path) and adds an explicit allow-all spec (+1 spec, 13 total)

## Test plan

- [ ] `make ci` passes (lint + build + internal tests)
- [ ] `go test -race ./integration/` passes (13/13 specs including the new allow-all spec)
- [ ] mTLS path unaffected — `config.go` still enforces a non-empty registry path at startup for `TLS_MODE=mtls`
- [ ] Startup warning is logged when registry path is unset

Closes #85