### PR TITLE
fix: align tenant_id in quick-start and examples with TOKEN_ENGINE_ISSUER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Unit tests (race + coverage)
         run: ginkgo -r --race --cover --coverprofile=coverage.out --randomize-all --fail-on-pending ./internal/...
 
+      - name: Integration tests
+        run: ginkgo --race --randomize-all --fail-on-pending ./integration/
+
       - name: Generate coverage report
         run: go tool cover -html=coverage.out -o coverage.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed empty caller registry in `TLS_MODE=disabled` denying every tenant-scoped RPC; when no
   `TOKEN_ENGINE_CALLER_REGISTRY_PATH` is set, all callers are now permitted and a startup warning
   is logged — mTLS mode is unaffected and still requires an explicit registry file
+- Fixed `tenant_id` in the README Quick Start client snippet (`"tenant-abc"` → `"my-service"`),
+  `examples/grpc-client`, and `examples/mtls-client` (`"default"` → reads from
+  `TOKEN_ENGINE_ISSUER` env var, defaulting to `"local-dev"`); API reference for `IssueToken`
+  now documents that `tenant_id` must equal the server's `TOKEN_ENGINE_ISSUER`
+
+### Chore
+
+- Integration test suite (`./integration/`) added to CI and `make test`; provides a smoke test
+  that asserts `IssueToken` succeeds end-to-end on every PR
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY   := token-engine
 PKG      := ./...
-TEST_PKG := ./internal/... ./client/...
+TEST_PKG := ./internal/... ./client/... ./integration/
 IMAGE    := angeltomala/token-engine
 VERSION  := $(shell git describe --tags --exact-match 2>/dev/null || echo "dev")
 DOCKER   := podman

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ client := tokenv1.NewTokenEngineClient(conn)
 
 resp, err := client.IssueToken(ctx, &tokenv1.IssueTokenRequest{
     Sub:      "user-123",
-    TenantId: "tenant-abc",
+    TenantId: "my-service",
 })
 ```
+
+`tenant_id` must equal the server's `TOKEN_ENGINE_ISSUER` — with the config above, that is `"my-service"`.
 
 ---
 
@@ -120,7 +122,7 @@ Issues a new access + refresh token pair.
 | Field | Type | Description |
 |---|---|---|
 | `sub` | string | Subject identifier (required) |
-| `tenant_id` | string | Tenant scoping for multi-tenancy (required) |
+| `tenant_id` | string | Must equal the server's `TOKEN_ENGINE_ISSUER` (required) |
 | `idempotency_key` | string | Deduplication key — same key returns same tokens within TTL |
 | `claims` | map<string,string> | Custom claims stamped on the access token |
 | `audiences` | repeated string | Audience override; defaults to `TOKEN_ENGINE_AUDIENCE` |

--- a/examples/grpc-client/README.md
+++ b/examples/grpc-client/README.md
@@ -12,6 +12,11 @@ A running token-engine instance with `TLS_MODE=disabled`. Quickest start:
 
     TOKEN_ENGINE_STATIC_KEY=devkey go run .
 
+`tenant_id` defaults to `local-dev` — the issuer configured in the root `docker-compose.yaml`.
+To target a server with a different issuer, pass `TOKEN_ENGINE_ISSUER` to match:
+
+    TOKEN_ENGINE_ISSUER=my-service TOKEN_ENGINE_STATIC_KEY=my-key go run .
+
 Optionally override the server address:
 
     TOKEN_ENGINE_ADDR=localhost:9090 TOKEN_ENGINE_STATIC_KEY=devkey go run .

--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -40,9 +40,10 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	tenantID := envOrDefault("TOKEN_ENGINE_ISSUER", "local-dev")
 	pair, err := c.IssueToken(ctx, &tokenv1.IssueTokenRequest{
 		Sub:      "user-123",
-		TenantId: "default",
+		TenantId: tenantID,
 	})
 	if err != nil {
 		log.Fatalf("IssueToken: %v", err)

--- a/examples/mtls-client/README.md
+++ b/examples/mtls-client/README.md
@@ -12,6 +12,10 @@ Falls back to plaintext if certificate paths are not set.
 
     CLIENT_CERT=client.crt CLIENT_KEY=client.key CA_CERT=ca.crt go run .
 
+`tenant_id` defaults to `local-dev`. Set `TOKEN_ENGINE_ISSUER` to match your server's issuer:
+
+    TOKEN_ENGINE_ISSUER=my-service CLIENT_CERT=client.crt CLIENT_KEY=client.key CA_CERT=ca.crt go run .
+
 ## Usage — plaintext fallback
 
     go run .

--- a/examples/mtls-client/main.go
+++ b/examples/mtls-client/main.go
@@ -50,9 +50,10 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	tenantID := envOrDefault("TOKEN_ENGINE_ISSUER", "local-dev")
 	pair, err := c.IssueToken(ctx, &tokenv1.IssueTokenRequest{
 		Sub:      "user-123",
-		TenantId: "default",
+		TenantId: tenantID,
 	})
 	if err != nil {
 		log.Fatalf("IssueToken: %v", err)


### PR DESCRIPTION
## Summary

- **README.md**: fixes `TenantId: "tenant-abc"` → `"my-service"` in the client snippet; adds a note that `tenant_id` must equal `TOKEN_ENGINE_ISSUER`; updates the IssueToken API reference row to state the constraint explicitly
- **examples/grpc-client**: `TenantId` now reads from `TOKEN_ENGINE_ISSUER` env var (default `"local-dev"`, matching root docker-compose); example README documents the override
- **examples/mtls-client**: same env-var pattern; example README documents the override
- **Makefile**: `./integration/` added to `TEST_PKG` — integration tests now run with `make test` and `make ci`
- **ci.yml**: new "Integration tests" step — `ginkgo ./integration/` runs the 13-spec end-to-end suite on every PR, providing the CI smoke test for `IssueToken` success

## Test plan

- [ ] `make ci` passes — lint + build + internal tests + integration tests (13 specs)
- [ ] `cd examples/grpc-client && go build ./...` succeeds
- [ ] `cd examples/mtls-client && go build ./...` succeeds
- [ ] README client snippet and API reference reflect `tenant_id = TOKEN_ENGINE_ISSUER` constraint
- [ ] CI Integration tests step appears in the Actions run and passes

Closes #86