### PR TITLE
fix: implement true refresh token rotation in RefreshToken RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed empty caller registry in `TLS_MODE=disabled` denying every tenant-scoped RPC; when no
   `TOKEN_ENGINE_CALLER_REGISTRY_PATH` is set, all callers are now permitted and a startup warning
   is logged — mTLS mode is unaffected and still requires an explicit registry file
+- Fixed `RefreshToken` returning an empty `refresh_token` — the RPC now performs true token
+  rotation, issuing a replacement refresh token alongside the new access token so clients can
+  chain successive refresh calls without re-authenticating
 - Fixed `tenant_id` in the README Quick Start client snippet (`"tenant-abc"` → `"my-service"`),
   `examples/grpc-client`, and `examples/mtls-client` (`"default"` → reads from
   `TOKEN_ENGINE_ISSUER` env var, defaulting to `"local-dev"`); API reference for `IssueToken`

--- a/examples/multi-tenant/main.go
+++ b/examples/multi-tenant/main.go
@@ -98,7 +98,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("RefreshToken (alpha): %v", err)
 	}
-	fmt.Printf("[tenant-alpha] refreshed access_token: %s\n\n", alphaRefreshed.GetAccessToken())
+	fmt.Printf("[tenant-alpha] refreshed access_token:  %s\n", alphaRefreshed.GetAccessToken())
+	fmt.Printf("[tenant-alpha] refreshed refresh_token: %s\n\n", alphaRefreshed.GetRefreshToken())
 
 	// ===== RefreshToken — tenant-beta =====
 	betaRefreshed, err := betaClient.RefreshToken(ctx, &tokenv1.RefreshTokenRequest{
@@ -108,7 +109,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("RefreshToken (beta): %v", err)
 	}
-	fmt.Printf("[tenant-beta]  refreshed access_token: %s\n\n", betaRefreshed.GetAccessToken())
+	fmt.Printf("[tenant-beta]  refreshed access_token:  %s\n", betaRefreshed.GetAccessToken())
+	fmt.Printf("[tenant-beta]  refreshed refresh_token: %s\n\n", betaRefreshed.GetRefreshToken())
 
 	// ===== Cross-tenant isolation =====
 	// Present tenant-alpha's refresh token to the alpha server but claim it belongs

--- a/integration/token_engine_test.go
+++ b/integration/token_engine_test.go
@@ -241,7 +241,40 @@ var _ = Describe("TokenEngine", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(refreshed.AccessToken).NotTo(BeEmpty())
-				// RefreshToken handler returns access token only — refresh_token field is not populated
+				Expect(refreshed.RefreshToken).NotTo(BeEmpty())
+			})
+		})
+
+		Context("when chaining successive refresh calls", func() {
+			It("each rotation returns a usable refresh token for the next call", func() {
+				ctx, cancel := authCtx()
+				defer cancel()
+
+				issued, err := client.IssueToken(ctx, &tokenv1.IssueTokenRequest{
+					Sub:      "chain-user",
+					TenantId: "test-issuer",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx2, cancel2 := authCtx()
+				defer cancel2()
+				first, err := client.RefreshToken(ctx2, &tokenv1.RefreshTokenRequest{
+					RefreshToken: issued.RefreshToken,
+					TenantId:     "test-issuer",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(first.AccessToken).NotTo(BeEmpty())
+				Expect(first.RefreshToken).NotTo(BeEmpty())
+
+				ctx3, cancel3 := authCtx()
+				defer cancel3()
+				second, err := client.RefreshToken(ctx3, &tokenv1.RefreshTokenRequest{
+					RefreshToken: first.RefreshToken,
+					TenantId:     "test-issuer",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(second.AccessToken).NotTo(BeEmpty())
+				Expect(second.RefreshToken).NotTo(BeEmpty())
 			})
 		})
 

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -223,9 +223,10 @@ Describe("Phase 3: RefreshToken", func() {
 	})
 
 	Context("when TenantRegistry.Get returns the Manager and token is valid", func() {
-		It("calls RefreshAccessTokenWithClaims and returns access_token", func() {
+		It("calls RefreshAccessTokenWithClaims and returns a full token pair", func() {
 			mockKM := testutil.NewMockKeyManager(ctrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			manager := buildRealManager(ctrl, mockKM)
 
 			// Issue a real token pair first
@@ -246,6 +247,7 @@ Describe("Phase 3: RefreshToken", func() {
 			Expect(err).To(BeNil())
 			Expect(resp).NotTo(BeNil())
 			Expect(resp.AccessToken).NotTo(BeEmpty())
+			Expect(resp.RefreshToken).NotTo(BeEmpty())
 		})
 	})
 
@@ -396,6 +398,7 @@ Describe("Phase 4: Observability", func() {
 			defer innerCtrl.Finish()
 			mockKM := testutil.NewMockKeyManager(innerCtrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			// Need to issue a token first using a handler with NoOpTracer
 			hNoOp := handler.NewTokenHandler(mockReg, audit.NewNoOpAuditStore(), obs.NewNoOpLogger(), obs.NewNoOpTracer(), obs.NewNoOpMetrics())
 			manager := buildRealManager(innerCtrl, mockKM)

--- a/internal/handler/token.go
+++ b/internal/handler/token.go
@@ -96,7 +96,8 @@ func (h *TokenHandler) IssueToken(ctx context.Context, req *tokenv1.IssueTokenRe
 	return &tokenv1.TokenPair{AccessToken: access, RefreshToken: refresh}, nil
 }
 
-// RefreshToken issues a new access token using a valid refresh token.
+// RefreshToken rotates the access and refresh token pair using a valid refresh token,
+// preserving custom claims on the replacement refresh token.
 func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTokenRequest) (*tokenv1.TokenPair, error) {
 	// ===== STEP 1: Open span =====
 	ctx, span := h.tracer.Start(ctx, "RefreshToken")
@@ -116,7 +117,7 @@ func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTok
 		customClaims[k] = v
 	}
 
-	// ===== STEP 4: Refresh access token =====
+	// ===== STEP 4: Rotate access token — revokes the presented refresh token atomically =====
 	access, err := manager.RefreshAccessTokenWithClaims(ctx, req.RefreshToken, customClaims)
 	if err != nil {
 		mapped := observability.MapLibraryError(err)
@@ -125,8 +126,26 @@ func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTok
 		return nil, mapped
 	}
 
+	// ===== STEP 5: Recover subject and audience from new access token =====
+	registered, err := manager.ValidateAccessToken(ctx, access)
+	if err != nil {
+		h.logger.Error(ctx, "failed to validate access token during refresh rotation", "error", err)
+		span.RecordError(err)
+		span.SetStatus(observability.StatusError, err.Error())
+		return nil, status.Error(codes.Internal, "refresh rotation: access token validation failed")
+	}
+
+	// ===== STEP 6: Issue replacement refresh token with original claims =====
+	refresh, err := manager.IssueRefreshTokenWithClaims(ctx, registered.Subject, customClaims, tokens.WithAudience([]string(registered.Audience)...))
+	if err != nil {
+		mapped := observability.MapLibraryError(err)
+		span.RecordError(mapped)
+		span.SetStatus(observability.StatusError, mapped.Error())
+		return nil, mapped
+	}
+
 	span.SetStatus(observability.StatusOK, "")
-	return &tokenv1.TokenPair{AccessToken: access}, nil
+	return &tokenv1.TokenPair{AccessToken: access, RefreshToken: refresh}, nil
 }
 
 // RevokeToken revokes a specific refresh token by resolving its token ID and revoking it.


### PR DESCRIPTION
## Summary

- `RefreshToken` previously called `RefreshAccessTokenWithClaims`, which atomically revoked the old refresh token but returned only a new access token — leaving callers locked out after one refresh call
- The RPC now performs true rotation via a three-step sequence: rotate access token → recover subject/audience from the new access token → issue a replacement refresh token with the same subject, audience, and custom claims
- Handler unit tests updated with `GetPublicKey` mock expectation (required by the new `ValidateAccessToken` step); success spec now asserts non-empty `refresh_token`
- Integration suite gains a chain spec (13 → 14) that verifies the returned refresh token can be used for a second successive `RefreshToken` call — directly satisfying the acceptance criterion

Closes #87

## Test plan

- [ ] `make ci` passes (lint + build + all internal unit tests)
- [ ] `ginkgo --race --randomize-all ./integration/` passes — 14 specs including the new chain spec
- [ ] `cd examples/multi-tenant && go build ./...` compiles cleanly