### PR TITLE
fix: populate access_token_expires_in and refresh_token_expires_in in TokenPair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed `RefreshToken` returning an empty `refresh_token` — the RPC now performs true token
   rotation, issuing a replacement refresh token alongside the new access token so clients can
   chain successive refresh calls without re-authenticating
+- Fixed `IssueToken` and `RefreshToken` returning always-zero `access_token_expires_in` and
+  `refresh_token_expires_in` — both RPCs now populate the fields with seconds-until-expiry
+  derived from the issued tokens
 - Fixed `tenant_id` in the README Quick Start client snippet (`"tenant-abc"` → `"my-service"`),
   `examples/grpc-client`, and `examples/mtls-client` (`"default"` → reads from
   `TOKEN_ENGINE_ISSUER` env var, defaulting to `"local-dev"`); API reference for `IssueToken`

--- a/integration/token_engine_test.go
+++ b/integration/token_engine_test.go
@@ -156,6 +156,8 @@ var _ = Describe("TokenEngine", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.AccessToken).NotTo(BeEmpty())
 				Expect(resp.RefreshToken).NotTo(BeEmpty())
+				Expect(resp.AccessTokenExpiresIn).To(BeNumerically(">", 0))
+				Expect(resp.RefreshTokenExpiresIn).To(BeNumerically(">", 0))
 			})
 		})
 
@@ -242,6 +244,8 @@ var _ = Describe("TokenEngine", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(refreshed.AccessToken).NotTo(BeEmpty())
 				Expect(refreshed.RefreshToken).NotTo(BeEmpty())
+				Expect(refreshed.AccessTokenExpiresIn).To(BeNumerically(">", 0))
+				Expect(refreshed.RefreshTokenExpiresIn).To(BeNumerically(">", 0))
 			})
 		})
 

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -81,6 +81,7 @@ Describe("Phase 3: IssueToken", func() {
 		It("calls IssueTokenPairWithClaims and returns access_token and refresh_token", func() {
 			mockKM := testutil.NewMockKeyManager(ctrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			manager := buildRealManager(ctrl, mockKM)
 
 			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
@@ -92,11 +93,14 @@ Describe("Phase 3: IssueToken", func() {
 			Expect(resp).NotTo(BeNil())
 			Expect(resp.AccessToken).NotTo(BeEmpty())
 			Expect(resp.RefreshToken).NotTo(BeEmpty())
+			Expect(resp.AccessTokenExpiresIn).To(BeNumerically(">", 0))
+			Expect(resp.RefreshTokenExpiresIn).To(BeNumerically(">", 0))
 		})
 
 		It("passes WithAudience option when req.Audiences is non-empty", func() {
 			mockKM := testutil.NewMockKeyManager(ctrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			manager := buildRealManager(ctrl, mockKM)
 
 			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
@@ -115,6 +119,7 @@ Describe("Phase 3: IssueToken", func() {
 		It("passes no WithAudience option when req.Audiences is empty", func() {
 			mockKM := testutil.NewMockKeyManager(ctrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			manager := buildRealManager(ctrl, mockKM)
 
 			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
@@ -133,6 +138,7 @@ Describe("Phase 3: IssueToken", func() {
 		It("converts req.Claims map[string]string to tokens.CustomClaims", func() {
 			mockKM := testutil.NewMockKeyManager(ctrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			manager := buildRealManager(ctrl, mockKM)
 
 			mockReg.EXPECT().Get(gomock.Any(), "test-tenant").Return(manager, nil)
@@ -248,6 +254,8 @@ Describe("Phase 3: RefreshToken", func() {
 			Expect(resp).NotTo(BeNil())
 			Expect(resp.AccessToken).NotTo(BeEmpty())
 			Expect(resp.RefreshToken).NotTo(BeEmpty())
+			Expect(resp.AccessTokenExpiresIn).To(BeNumerically(">", 0))
+			Expect(resp.RefreshTokenExpiresIn).To(BeNumerically(">", 0))
 		})
 	})
 
@@ -255,6 +263,7 @@ Describe("Phase 3: RefreshToken", func() {
 		It("returns codes.PermissionDenied", func() {
 			mockKM := testutil.NewMockKeyManager(ctrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			mockKM.EXPECT().Start(gomock.Any()).Return(nil)
 			mockKM.EXPECT().Shutdown(gomock.Any()).Return(nil).AnyTimes()
 			memStore := storage.NewMemoryRefreshStore(storage.MemoryRefreshStoreConfig{})
@@ -362,6 +371,7 @@ Describe("Phase 4: Observability", func() {
 			defer innerCtrl.Finish()
 			mockKM := testutil.NewMockKeyManager(innerCtrl)
 			mockKM.EXPECT().GetCurrentSigningKey(gomock.Any()).Return(privateKey, "key-1", nil).AnyTimes()
+			mockKM.EXPECT().GetPublicKey(gomock.Any(), "key-1").Return(&privateKey.PublicKey, nil).AnyTimes()
 			manager := buildRealManager(innerCtrl, mockKM)
 
 			mockTracer.EXPECT().Start(gomock.Any(), "IssueToken").Return(ctx, mockSpan)

--- a/internal/handler/token.go
+++ b/internal/handler/token.go
@@ -57,7 +57,8 @@ func NewTokenHandler(
 	}
 }
 
-// IssueToken issues a new access/refresh token pair for the requesting tenant.
+// IssueToken issues a new access/refresh token pair for the requesting tenant,
+// populating access_token_expires_in and refresh_token_expires_in with seconds-until-expiry.
 func (h *TokenHandler) IssueToken(ctx context.Context, req *tokenv1.IssueTokenRequest) (*tokenv1.TokenPair, error) {
 	// ===== STEP 1: Open span =====
 	ctx, span := h.tracer.Start(ctx, "IssueToken")
@@ -92,12 +93,36 @@ func (h *TokenHandler) IssueToken(ctx context.Context, req *tokenv1.IssueTokenRe
 		return nil, mapped
 	}
 
+	// ===== STEP 6: Recover expiry values =====
+	registered, err := manager.ValidateAccessToken(ctx, access)
+	if err != nil {
+		h.logger.Error(ctx, "failed to validate access token during issuance", "error", err)
+		span.RecordError(err)
+		span.SetStatus(observability.StatusError, err.Error())
+		return nil, status.Error(codes.Internal, "issuance: access token validation failed")
+	}
+	accessExpiresIn := expiresInSeconds(registered.ExpiresAt.Time)
+
+	refreshMeta, err := manager.IntrospectToken(ctx, refresh)
+	if err != nil {
+		mapped := observability.MapLibraryError(err)
+		span.RecordError(mapped)
+		span.SetStatus(observability.StatusError, mapped.Error())
+		return nil, mapped
+	}
+	refreshExpiresIn := expiresInSeconds(refreshMeta.ExpiresAt)
+
 	span.SetStatus(observability.StatusOK, "")
-	return &tokenv1.TokenPair{AccessToken: access, RefreshToken: refresh}, nil
+	return &tokenv1.TokenPair{
+		AccessToken:           access,
+		RefreshToken:          refresh,
+		AccessTokenExpiresIn:  accessExpiresIn,
+		RefreshTokenExpiresIn: refreshExpiresIn,
+	}, nil
 }
 
 // RefreshToken rotates the access and refresh token pair using a valid refresh token,
-// preserving custom claims on the replacement refresh token.
+// preserving custom claims on the replacement tokens and populating expiry fields.
 func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTokenRequest) (*tokenv1.TokenPair, error) {
 	// ===== STEP 1: Open span =====
 	ctx, span := h.tracer.Start(ctx, "RefreshToken")
@@ -126,7 +151,7 @@ func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTok
 		return nil, mapped
 	}
 
-	// ===== STEP 5: Recover subject and audience from new access token =====
+	// ===== STEP 5: Recover subject, audience, and access expiry from new access token =====
 	registered, err := manager.ValidateAccessToken(ctx, access)
 	if err != nil {
 		h.logger.Error(ctx, "failed to validate access token during refresh rotation", "error", err)
@@ -134,6 +159,7 @@ func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTok
 		span.SetStatus(observability.StatusError, err.Error())
 		return nil, status.Error(codes.Internal, "refresh rotation: access token validation failed")
 	}
+	accessExpiresIn := expiresInSeconds(registered.ExpiresAt.Time)
 
 	// ===== STEP 6: Issue replacement refresh token with original claims =====
 	refresh, err := manager.IssueRefreshTokenWithClaims(ctx, registered.Subject, customClaims, tokens.WithAudience([]string(registered.Audience)...))
@@ -144,8 +170,23 @@ func (h *TokenHandler) RefreshToken(ctx context.Context, req *tokenv1.RefreshTok
 		return nil, mapped
 	}
 
+	// ===== STEP 7: Recover refresh token expiry =====
+	refreshMeta, err := manager.IntrospectToken(ctx, refresh)
+	if err != nil {
+		mapped := observability.MapLibraryError(err)
+		span.RecordError(mapped)
+		span.SetStatus(observability.StatusError, mapped.Error())
+		return nil, mapped
+	}
+	refreshExpiresIn := expiresInSeconds(refreshMeta.ExpiresAt)
+
 	span.SetStatus(observability.StatusOK, "")
-	return &tokenv1.TokenPair{AccessToken: access, RefreshToken: refresh}, nil
+	return &tokenv1.TokenPair{
+		AccessToken:           access,
+		RefreshToken:          refresh,
+		AccessTokenExpiresIn:  accessExpiresIn,
+		RefreshTokenExpiresIn: refreshExpiresIn,
+	}, nil
 }
 
 // RevokeToken revokes a specific refresh token by resolving its token ID and revoking it.
@@ -368,4 +409,14 @@ func (h *TokenHandler) RevokeAllForUserAndAudience(ctx context.Context, req *tok
 	// ===== STEP 6: Success =====
 	span.SetStatus(observability.StatusOK, "")
 	return &tokenv1.RevokeTokenResponse{}, nil
+}
+
+// expiresInSeconds returns the number of whole seconds until t, clamped to zero
+// for times already in the past.
+func expiresInSeconds(t time.Time) int64 {
+	d := time.Until(t)
+	if d <= 0 {
+		return 0
+	}
+	return int64(d.Seconds())
 }


### PR DESCRIPTION
## Summary

- `IssueToken` and `RefreshToken` both returned always-zero `access_token_expires_in` / `refresh_token_expires_in` fields in `TokenPair`, despite those fields being documented in the README and proto as seconds-until-expiry
- Both RPCs now populate the fields by recovering expiry timestamps from the freshly-issued tokens: `ValidateAccessToken` for the JWT access token, `IntrospectToken` for the opaque refresh token
- A private `expiresInSeconds` helper computes and clamps the value to zero for already-expired tokens

## Test plan

- [ ] `make ci` passes (67 handler specs, 14 integration specs, all green)
- [ ] Primary `IssueToken` success test asserts `AccessTokenExpiresIn > 0` and `RefreshTokenExpiresIn > 0`
- [ ] Primary `RefreshToken` success test asserts both expiry fields are positive
- [ ] Integration `IssueToken` spec ("returns a non-empty access token, refresh token, and positive expiry values") now asserts the fields it describes
- [ ] Integration `RefreshToken` "when refresh token is valid" spec asserts both expiry fields

Closes #88